### PR TITLE
Add correct UTF8 BOM handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,12 @@ or as a dependency:
 $ npm install --save fury
 ```
 
-### Interface
+### Legacy Interface
+
+For now Fury.js offers only "legacy" interface for API Blueprint
+and Apiary Blueprint parsing.
 
 #### API Blueprint Parsing
-
-In the interim period Fury.js offers only "legacy" interface for API Blueprint
-and Apiary Blueprint parsing:
-
 
 ```js
 var parser = require('fury').legacyBlueprintParser;

--- a/src/legacy/blueprint-parser.coffee
+++ b/src/legacy/blueprint-parser.coffee
@@ -8,7 +8,7 @@ DefaultFuryEmitter = require '../fury-emitter'
 apiBlueprintAdapter = require './api-blueprint-adapter'
 apiaryBlueprintAdapter = require './apiary-blueprint-adapter'
 
-NEW_VERSION_REGEXP = new RegExp '^(((VERSION:( |\t)2)|(FORMAT:( |\t)(X-)?1A))\n)', 'i'
+NEW_VERSION_REGEXP = new RegExp '^[\uFEFF]?(((VERSION:( |\t)2)|(FORMAT:( |\t)(X-)?1A))\n)', 'i'
 
 STRICT_OPTIONS =
   requireBlueprintName: true

--- a/test/unit/legacy/blueprint-parser-test.js
+++ b/test/unit/legacy/blueprint-parser-test.js
@@ -1,0 +1,35 @@
+var assert = require('chai').assert;
+var bluperintParser = require('../../../src/legacy/blueprint-parser');
+
+describe('Legacy blueprint parser', function() {
+  describe('recognizes Format 1A', function() {
+
+    var source =  'FORMAT: 1A\n\n' +
+                  '#My API\n';
+
+    it('verbatim', function() {
+      assert.ok(bluperintParser.newVersionRegExp.test(source));
+    });
+
+    it('with UTF8 BOM', function() {
+      var bomSource = '\uFEFF' + source;
+      assert.ok(bluperintParser.newVersionRegExp.test(bomSource));
+    });
+  });
+
+  describe('recognizes legacy format', function() {
+
+    var source =  'HOST: http://www.google.com/\n\n' +
+                  '--- Sample API v2 ---\n';
+
+    it('verbatim', function() {
+      assert.notOk(bluperintParser.newVersionRegExp.test(source));
+    });
+
+    it('with UTF8 BOM', function() {
+      var bomSource = '\uFEFF' + source;
+      assert.notOk(bluperintParser.newVersionRegExp.test(bomSource));
+    });
+  });
+
+});

--- a/tools/fury.js
+++ b/tools/fury.js
@@ -1,0 +1,25 @@
+var fs = require('fs');
+var path = require('path');
+var parser = require('../lib/fury').legacyBlueprintParser;
+
+// Process arguments
+var args = process.argv.slice(2);
+if (typeof args == 'undefined' || args.length !== 1) {
+  var scriptName = path.basename(process.argv[1]);
+  console.log('usage: ' + scriptName + ' <input file>\n');
+  process.exit(0);
+}
+
+// Read & parse
+fs.readFile(args[0], 'utf8', function (err, data) {
+  if (err) throw err;
+
+  parser.parse({ code: data }, function(error, api, warnings) {
+    if (error) {
+        console.log(JSON.stringify(error, null, 2));
+        process.exit(error.code);
+    }
+
+    console.log(JSON.stringify(api, null, 2));
+  });
+});


### PR DESCRIPTION
`NEW_VERSION_REGEXP` wasn't taking possible UTF8 BOM into account and therefore failed to match otherwise correct FORMAT 1A blueprints. As reported here https://github.com/apiaryio/apiary-client/issues/70
