### PR TITLE
Update tool to lint while directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "coveralls": "^2.11.2",
     "jscoverage": "^0.5.9",
     "mocha": "~2.1",
-    "mocha-lcov-reporter": "0.0.2"
+    "mocha-lcov-reporter": "0.0.2",
+    "async": "~0.9.0"
   },
   "license": "MIT"
 }

--- a/tools/fury.js
+++ b/tools/fury.js
@@ -26,8 +26,10 @@ function createParseFunction(filePath) {
       }
 
       // For debug puproses
-      if (PRINT_PARSE_RESULT)
+      if (PRINT_PARSE_RESULT) {
+        console.log('Parse results:');
         console.log(JSON.stringify(api, null, 2));
+      }
       return callback();
     });
   };
@@ -58,8 +60,7 @@ var series = [];
 var stats = fs.statSync(args[0]);
 if (stats.isFile()) {
   series.push(createParseFunction(args[0]));
-}
-else if (stats.isDirectory()) {
+} else if (stats.isDirectory()) {
   series = collectDirectory(args[0]);
 }
 

--- a/tools/fury.js
+++ b/tools/fury.js
@@ -1,25 +1,73 @@
 var fs = require('fs');
 var path = require('path');
 var parser = require('../lib/fury').legacyBlueprintParser;
+var async = require('async');
+
+// TODO: Turn into a CLI argument
+var PRINT_PARSE_RESULT = false;
 
 // Process arguments
 var args = process.argv.slice(2);
 if (typeof args == 'undefined' || args.length !== 1) {
   var scriptName = path.basename(process.argv[1]);
-  console.log('usage: ' + scriptName + ' <input file>\n');
+  console.log('usage: ' + scriptName + ' <input file>|<input directory>\n');
   process.exit(0);
 }
 
-// Read & parse
-fs.readFile(args[0], 'utf8', function (err, data) {
-  if (err) throw err;
+// Creates parsing functions to be run in series
+function createParseFunction(filePath) {
+  return function(callback) {
+    var data = fs.readFileSync(filePath, 'utf8');
+    console.log('processing ' + filePath + ' ...');
+    parser.parse({ code: data }, function(error, api, warnings) {
+      if (error) {
 
-  parser.parse({ code: data }, function(error, api, warnings) {
-    if (error) {
-        console.log(JSON.stringify(error, null, 2));
-        process.exit(error.code);
+        return callback(error);
+      }
+
+      // For debug puproses
+      if (PRINT_PARSE_RESULT)
+        console.log(JSON.stringify(api, null, 2));
+      return callback();
+    });
+  };
+}
+
+// Walk through a directory and process every in it file
+function collectDirectory(dirPath) {
+  var parseFunctions = [];
+
+  fs.readdirSync(dirPath).forEach(function(name) {
+    var filePath = path.join(dirPath, name);
+    var stat = fs.statSync(filePath);
+    if (stat.isFile() && (path.extname(filePath) === '.apib'
+                          || path.extname(filePath) === '.md')) {
+      parseFunctions.push(createParseFunction(filePath));
     }
-
-    console.log(JSON.stringify(api, null, 2));
+    // Do not recurse into directories for now
+    // else if (stat.isDirectory()) {
+    //     processDirectory(filePath, callback);
+    // }
   });
+
+  return parseFunctions;
+}
+
+// Query input
+var series = [];
+var stats = fs.statSync(args[0]);
+if (stats.isFile()) {
+  series.push(createParseFunction(args[0]));
+}
+else if (stats.isDirectory()) {
+  series = collectDirectory(args[0]);
+}
+
+console.log('processing ' + series.length + ' file(s)');
+async.series(series, function(error) {
+  if (error) {
+    console.log(error);
+  }
+
+  console.log('\ndone.');
 });


### PR DESCRIPTION
This commit updates the fury CLI tool to lint not only one file but
whole directories of blueprints. Useful when validating a batch of
blueprints e.g. from a suite vault.
