### PR TITLE
Add API Blueprint serializer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "minim": "^0.4.0",
     "robotskirt": "",
     "sanitizer": "",
+    "swig": "^1.4.2",
     "underscore": ""
   },
   "devDependencies": {
@@ -39,6 +40,7 @@
     "coffee-script": "~1.9",
     "coveralls": "^2.11.2",
     "eslint": "^0.21.2",
+    "glob": "^5.0.10",
     "istanbul": "^0.3.13",
     "mocha": "^2.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "apiary-blueprint-parser": "",
     "drafter": "^0.2.5",
-    "minim": "^0.4.0",
+    "minim": "^0.5.0",
     "robotskirt": "",
     "sanitizer": "",
     "swig": "^1.4.2",

--- a/src/adapters/api-blueprint.es6
+++ b/src/adapters/api-blueprint.es6
@@ -29,7 +29,31 @@ function indent(input, spaces) {
   return lines.join('\n').trim();
 }
 
+/*
+ * Given a message payload, return true iff it only has a body defined and
+ * optionally has a content-type and nothing else. This lets us know when to
+ * use a shorthand syntax in the template.
+ */
+function bodyOnly(payload) {
+  let headers;
+
+  // First, we need to filter out the content-type header. This is handled
+  // outside of the payload (e.g. `+ Response (application/json)`)
+  if (payload.headers) {
+    headers = payload.headers.filter(
+      h => h.meta.name.toLowerCase() !== 'content-type');
+  }
+
+  if (payload.messageBody && !(headers.length || payload.dataStructure ||
+                               payload.messageBodySchema)) {
+    return true;
+  }
+
+  return false;
+}
+
 swig.setFilter('indent', indent);
+swig.setFilter('bodyOnly', bodyOnly);
 
 export const name = 'api-blueprint';
 export const mediaTypes = [

--- a/src/adapters/api-blueprint.es6
+++ b/src/adapters/api-blueprint.es6
@@ -30,7 +30,7 @@ function indent(input, spaces) {
 }
 
 /*
- * Given a message payload, return true iff it only has a body defined and
+ * Given a message payload, return true if it only has a body defined and
  * optionally has a content-type and nothing else. This lets us know when to
  * use a shorthand syntax in the template.
  */
@@ -40,16 +40,11 @@ function bodyOnly(payload) {
   // First, we need to filter out the content-type header. This is handled
   // outside of the payload (e.g. `+ Response (application/json)`)
   if (payload.headers) {
-    headers = payload.headers.filter(
-      h => h.meta.name.toLowerCase() !== 'content-type');
+    headers = payload.headers.exclude('Content-Type');
   }
 
-  if (payload.messageBody && !(headers.length || payload.dataStructure ||
-                               payload.messageBodySchema)) {
-    return true;
-  }
-
-  return false;
+  return payload.messageBody && !(headers.length || payload.dataStructure ||
+                                  payload.messageBodySchema);
 }
 
 swig.setFilter('indent', indent);

--- a/src/adapters/api-blueprint.es6
+++ b/src/adapters/api-blueprint.es6
@@ -47,8 +47,19 @@ function bodyOnly(payload) {
                                   payload.messageBodySchema);
 }
 
+/*
+ * Detect when it is okay to use a resource shorthand, i.e. skip the resource
+ * header and just do a single action with a URI.
+ */
+function resourceShorthand(resource) {
+  return (!resource.title && !resource.description &&
+          resource.transitions.length === 1 &&
+          resource.transitions.get(0).computedHref);
+}
+
 swig.setFilter('indent', indent);
 swig.setFilter('bodyOnly', bodyOnly);
+swig.setFilter('resourceShorthand', resourceShorthand);
 
 export const name = 'api-blueprint';
 export const mediaTypes = [

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -74,7 +74,12 @@ class HttpHeaders extends ApiBaseArray {
   }
 }
 
-class HrefVariables extends ObjectType {}
+class HrefVariables extends ObjectType {
+  constructor(...args) {
+    super(...args);
+    this.element = 'hrefVariables';
+  }
+}
 
 export class Asset extends ElementType {
   constructor(...args) {

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -31,19 +31,19 @@ import {filterBy} from './util';
  */
 class ApiBaseArray extends ArrayType {
   get title() {
-    return this.meta.title.toValue();
+    return this.meta.title && this.meta.title.toValue();
   }
 
   set title(value) {
-    this.meta.title.set(value);
+    this.meta.title = value;
   }
 
   get description() {
-    return this.meta.description.toValue();
+    return this.meta.description && this.meta.description.toValue();
   }
 
   set description(value) {
-    this.meta.description.set(value);
+    this.meta.description = value;
   }
 
   hasClass(name) {
@@ -52,7 +52,28 @@ class ApiBaseArray extends ArrayType {
   }
 }
 
-class HttpHeaders extends ApiBaseArray {}
+class HttpHeaders extends ApiBaseArray {
+  constructor(...args) {
+    super(...args);
+    this.element = 'httpHeaders';
+  }
+
+  exclude(name) {
+    return this.filter(item => {
+      let itemName = item.meta.getProperty('name');
+
+      if (!itemName) {
+        // This can't possibly match, so we include it in the results.
+        return true;
+      }
+
+      // Note: this may not be a string, hence the duck-type check below!
+      itemName = itemName.toValue();
+      return !(itemName.toLowerCase) || itemName.toLowerCase() !== name.toLowerCase();
+    });
+  }
+}
+
 class HrefVariables extends ObjectType {}
 
 export class Asset extends ElementType {

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -45,6 +45,11 @@ class ApiBaseArray extends ArrayType {
   set description(value) {
     this.meta.description.set(value);
   }
+
+  hasClass(name) {
+    return this.meta && this.meta.class && this.meta.class.indexOf &&
+           this.meta.class.indexOf(name) !== -1;
+  }
 }
 
 class HttpHeaders extends ApiBaseArray {}
@@ -89,11 +94,25 @@ class HttpMessagePayload extends ApiBaseArray {
   }
 
   header(name) {
-    const header = this.attributes.headers.content.filter(filterBy.bind(this, {
-      name,
-      ignoreCase: true
-    }))[0];
+    const headers = this.attributes.headers;
+    let header = null;
+
+    if (headers) {
+      header = headers.content.filter(filterBy.bind(this, {
+        name,
+        ignoreCase: true
+      }))[0];
+    }
+
     return header ? header.content : header;
+  }
+
+  get contentType() {
+    if (this.header('Content-Type')) {
+      return this.header('Content-Type');
+    }
+
+    return this.content && this.content.contentType;
   }
 
   get dataStructure() {
@@ -187,6 +206,14 @@ export class Transition extends ApiBaseArray {
 
   set href(value) {
     this.attributes.href = value;
+  }
+
+  get computedHref() {
+    try {
+      return this.href ? this.href : this.transactions.get(0).request.href;
+    } catch (err) {
+      return null;
+    }
   }
 
   get parameters() {

--- a/src/refract/util.es6
+++ b/src/refract/util.es6
@@ -19,13 +19,13 @@ export function filterBy(options, item) {
   if (options.element && item.element !== options.element) {
     return false;
   }
-  if (options.name && item.meta.name.toValue()) {
+  if (options.name && item.meta.name) {
     if (options.ignoreCase) {
-      if (item.meta.name.toValue().toLowerCase() !== options.name.toLowerCase()) {
+      if (item.meta.name.toLowerCase() !== options.name.toLowerCase()) {
         return false;
       }
     } else {
-      if (item.meta.name.toValue() !== options.name) {
+      if (item.meta.name !== options.name) {
         return false;
       }
     }

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -6,12 +6,15 @@ FORMAT: 1A
 
 
 {% macro renderExample(example) %}
+{% if example|bodyOnly %}
+        {{ example.messageBody.content|indent(8) }}
+{% else %}
   {% if example.headers && example.headers.length > 1 %}
     + Headers
 
       {% for header in example.headers.content %}
         {% if header.meta.name.toLowerCase() != 'content-type' %}
-        + {{ header.meta.name }}: {{ header.content }}
+            {{ header.meta.name }}: {{ header.content }}
         {% endif %}
       {% endfor %}
 
@@ -22,7 +25,29 @@ FORMAT: 1A
             {{ example.messageBody.content|indent(12) }}
 
   {% endif %}
+  {% if example.messageBodySchema %}
+    + Schema
+
+            {{ example.messageBodySchema.content|indent(12) }}
+
+  {% endif %}
+{% endif %}
 {% endmacro %}
+
+
+
+
+
+
+{% macro renderParameters(hrefVariables) %}
++ Parameters
+
+  {% for hrefVar in hrefVariables.content %}
+    + {{ hrefVar.meta.name }}{% if hrefVar.attributes.typeAttributes %} ({{ hrefVar.attributes.typeAttributes }}){% endif %}{% if hrefVar.meta.description %} - {{ hrefVar.meta.description }}{% endif %}
+  {% endfor %}
+
+{% endmacro %}
+
 
 
 
@@ -45,12 +70,16 @@ FORMAT: 1A
 
 {% macro renderTransition(transition) %}
 {% if transition.title %}
-#### {{ transition.title }} ({{ transition.transactions.get(0).request.method }}{% if transition.computedHref %} {{ transition.computedHref }}{% endif %}
+#### {{ transition.title }} [{{ transition.transactions.get(0).request.method }}{% if transition.computedHref %} {{ transition.computedHref }}{% endif %}]
 {% else %}
 #### {{ transition.transactions.get(0).request.method }}{% if transition.computedHref %} {{ transition.computedHref }}{% endif %}
 {% endif %}
 
 {{ transition.description }}
+
+{% if resource.parameters.length %}
+{{ renderParameters(resource.parameters) }}
+{% endif %}
 
 {% for transaction in transition.transactions.content %}
   {{ renderTransaction(transaction) }}
@@ -63,9 +92,12 @@ FORMAT: 1A
 
 {% macro renderResource(resource) %}
 {% if resource.title %}
-### {{ resource.title }} ({{ resource.href }})
+### {{ resource.title }} [{{ resource.href }}]
 
 {{ resource.description }}
+{% endif %}
+{% if resource.hrefVariables.length %}
+{{ renderParameters(resource.hrefVariables) }}
 {% endif %}
 {% for transition in resource.transitions.content %}
   {{ renderTransition(transition) }}

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -41,7 +41,7 @@ FORMAT: 1A
 + Parameters
 
   {% for item in hrefVariables.content %}
-    + {{ item.key.toValue() }}{% if item.value.attributes.typeAttributes %} ({{ item.value.attributes.typeAttributes }}){% endif %}{% if item.value.meta.description %} - {{ item.value.meta.description.toValue() }}{% endif %}
+    + {{ item.key.toValue() }}{% if item.attributes.typeAttributes %} ({{ item.attributes.typeAttributes }}){% endif %}{% if item.value.meta.description.toValue() %} - {{ item.value.meta.description.toValue() }}{% endif %}
   {% endfor %}
 
 {% endmacro %}
@@ -93,8 +93,8 @@ FORMAT: 1A
 
 
 {% macro renderResource(resource) %}
-{% if resource.title %}
-### {{ resource.title }} [{{ resource.href }}]
+{% if !resource|resourceShorthand %}
+### {{ resource.title|default('Resource') }} [{{ resource.href }}]
 
 {{ resource.description }}
 {% endif %}
@@ -111,11 +111,10 @@ FORMAT: 1A
 
 
 {% macro renderGroup(group) %}
-{% if group.title || group.description %}
 ## Group {{ group.title }}
 
 {{ group.description }}
-{% endif %}
+
 {{ renderCategory(group) }}
 {% endmacro %}
 

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -1,0 +1,105 @@
+FORMAT: 1A
+{% if api.meta.HOST %}HOST: {{ api.meta.HOST }}{% endif %}
+
+
+
+
+
+{% macro renderExample(example) %}
+  {% if example.headers && example.headers.length > 1 %}
+    + Headers
+
+      {% for header in example.headers.content %}
+        {% if header.meta.name.toLowerCase() != 'content-type' %}
+        + {{ header.meta.name }}: {{ header.content }}
+        {% endif %}
+      {% endfor %}
+
+  {% endif %}
+  {% if example.messageBody %}
+    + Body
+
+            {{ example.messageBody.content|indent(12) }}
+
+  {% endif %}
+{% endmacro %}
+
+
+
+
+
+{% macro renderTransaction(transaction) %}
+{% if transaction.request && (transaction.request.contentType || transaction.request.headers || transaction.request.dataStructure || transaction.request.messageBody || transaction.request.messageBodySchema) %}
++ Request{% if transaction.request.contentType %} ({{ transaction.request.contentType }}){% endif %}
+{{ renderExample(transaction.request) }}
+{% endif %}
+{% if transaction.response %}
++ Response{% if transaction.response.statusCode %} {{ transaction.response.statusCode }}{% endif %}{% if transaction.response.contentType %} ({{ transaction.response.contentType }}){% endif %}
+{{ renderExample(transaction.response) }}
+{% endif %}
+{% endmacro %}
+
+
+
+
+
+{% macro renderTransition(transition) %}
+{% if transition.title %}
+#### {{ transition.title }} ({{ transition.transactions.get(0).request.method }}{% if transition.computedHref %} {{ transition.computedHref }}{% endif %}
+{% else %}
+#### {{ transition.transactions.get(0).request.method }}{% if transition.computedHref %} {{ transition.computedHref }}{% endif %}
+{% endif %}
+
+{{ transition.description }}
+
+{% for transaction in transition.transactions.content %}
+  {{ renderTransaction(transaction) }}
+{% endfor %}
+{% endmacro %}
+
+
+
+
+
+{% macro renderResource(resource) %}
+{% if resource.title %}
+### {{ resource.title }} ({{ resource.href }})
+
+{{ resource.description }}
+{% endif %}
+{% for transition in resource.transitions.content %}
+  {{ renderTransition(transition) }}
+{% endfor %}
+{% endmacro %}
+
+
+
+
+
+{% macro renderGroup(group) %}
+{% if group.title || group.description %}
+## Group {{ group.title }}
+
+{{ group.description }}
+{% endif %}
+{% for resource in group.resources.content %}
+  {{ renderResource(resource) }}
+{% endfor %}
+{% endmacro %}
+
+
+
+
+
+# {{ api.title|default('API Documentation') }}
+
+{{ api.description }}
+
+{% for item in api.content %}
+  {% if item.meta.class.indexOf('resourceGroup') !== -1 %}
+    {{ renderGroup(item) }}
+  {% endif %}
+  {% if item.element === 'resource' %}
+    {{ renderResource(item) }}
+  {% endif %}
+{% endfor %}

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -114,10 +114,28 @@ FORMAT: 1A
 
 {{ group.description }}
 {% endif %}
-{% for resource in group.resources.content %}
-  {{ renderResource(resource) }}
-{% endfor %}
+{{ renderCategory(group) }}
 {% endmacro %}
+
+
+
+
+
+{% macro renderCategory(category) %}
+  {# Categories can contain copy (text) elements, other categories, and resources #}
+  {% for item in category.content %}
+    {% if item.element === 'copy' %}
+{{ item.content }}
+    {% endif %}
+    {% if item.element === 'category' && item.meta.class.indexOf('resourceGroup') !== -1 %}
+      {{ renderGroup(item) }}
+    {% endif %}
+    {% if item.element === 'resource' %}
+      {{ renderResource(item) }}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
 
 
 
@@ -127,11 +145,4 @@ FORMAT: 1A
 
 {{ api.description }}
 
-{% for item in api.content %}
-  {% if item.meta.class.indexOf('resourceGroup') !== -1 %}
-    {{ renderGroup(item) }}
-  {% endif %}
-  {% if item.element === 'resource' %}
-    {{ renderResource(item) }}
-  {% endif %}
-{% endfor %}
+{{ renderCategory(api) }}

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -66,11 +66,11 @@ FORMAT: 1A
 
 
 
-{% macro renderTransition(transition) %}
+{% macro renderTransition(transition, href) %}
 {% if transition.title %}
-#### {{ transition.title }} [{{ transition.transactions.get(0).request.method }}{% if transition.computedHref %} {{ transition.computedHref }}{% endif %}]
+#### {{ transition.title }} [{{ transition.transactions.get(0).request.method }}{% if href %} {{ href }}{% elseif transition.computedHref %} {{ transition.computedHref }}{% endif %}]
 {% else %}
-#### {{ transition.transactions.get(0).request.method }}{% if transition.computedHref %} {{ transition.computedHref }}{% endif %}
+#### {{ transition.transactions.get(0).request.method }}{% if href %} {{ href }}{% elseif transition.computedHref %} {{ transition.computedHref }}{% endif %}
 {% endif %}
 
 {{ transition.description }}
@@ -94,15 +94,22 @@ FORMAT: 1A
 
 {% macro renderResource(resource) %}
 {% if !resource|resourceShorthand %}
+{% set href = null %}
 ### {{ resource.title|default('Resource') }} [{{ resource.href }}]
 
 {{ resource.description }}
+{% else %}
+  {#
+    We are using the shorthand, make sure to pass any href down to the
+    transition layer.
+  #}
+  {% set href = resource.href %}
 {% endif %}
 {% if resource.hrefVariables.length %}
 {{ renderParameters(resource.hrefVariables) }}
 {% endif %}
 {% for transition in resource.transitions.content %}
-  {{ renderTransition(transition) }}
+  {{ renderTransition(transition, href) }}
 {% endfor %}
 {% endmacro %}
 

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -77,8 +77,12 @@ FORMAT: 1A
 
 {{ transition.description }}
 
-{% if resource.parameters.length %}
-{{ renderParameters(resource.parameters) }}
+{% if transition.parameters.length %}
+  {{ renderParameters(transition.parameters) }}
+{% endif %}
+
+{% if transition.relation %}
++ Relation: {{ transition.relation }}
 {% endif %}
 
 {% for transaction in transition.transactions.content %}

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -9,13 +9,11 @@ FORMAT: 1A
 {% if example|bodyOnly %}
         {{ example.messageBody.content|indent(8) }}
 {% else %}
-  {% if example.headers && example.headers.length > 1 %}
+  {% if example.headers.exclude('Content-Type').length %}
     + Headers
 
-      {% for header in example.headers.content %}
-        {% if header.meta.name.toLowerCase() != 'content-type' %}
-            {{ header.meta.name }}: {{ header.content }}
-        {% endif %}
+      {% for header in example.headers.exclude('Content-Type').content %}
+            {{ header.meta.getProperty('name').content }}: {{ header.content }}
       {% endfor %}
 
   {% endif %}
@@ -42,8 +40,8 @@ FORMAT: 1A
 {% macro renderParameters(hrefVariables) %}
 + Parameters
 
-  {% for hrefVar in hrefVariables.content %}
-    + {{ hrefVar.meta.name }}{% if hrefVar.attributes.typeAttributes %} ({{ hrefVar.attributes.typeAttributes }}){% endif %}{% if hrefVar.meta.description %} - {{ hrefVar.meta.description }}{% endif %}
+  {% for item in hrefVariables.content %}
+    + {{ item.key.toValue() }}{% if item.value.attributes.typeAttributes %} ({{ item.value.attributes.typeAttributes }}){% endif %}{% if item.value.meta.description %} - {{ item.value.meta.description.toValue() }}{% endif %}
   {% endfor %}
 
 {% endmacro %}

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -10,8 +10,11 @@ const refractedApi = [
       ['resource', {title: 'Frob', description: 'A frob does something.'}, {
         href: '/frobs/{id}',
         hrefVariables: ['hrefVariables', {}, {}, [
-            ['string', {name: 'id'}, {}, '']
-          ]]
+          ['member', {}, {}, {
+            'key': ['string', {}, {}, 'id'],
+            'value': ['string', {}, {}, '']
+          }]
+        ]]
         }, [
         ['dataStructure', {}, {}, [
           ['string', {name: 'id'}, {}, null],

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -3,6 +3,35 @@ import fury, {
   Fury, legacyBlueprintParser, legacyMarkdownRenderer
 } from '../../lib/fury';
 
+const refractedApi = [
+  'category', {'class': ['api'], title: 'My API', description: 'An API description.'}, {}, [
+    ['category', {'class': ['resourceGroup'], title: 'My Group', description: 'This is a group of resources'}, {}, [
+      ['copy', {}, {contentType: 'text/plain'}, 'Extra text'],
+      ['resource', {title: 'Frob', description: 'A frob does something.'}, {
+        href: '/frobs/{id}',
+        hrefVariables: ['hrefVariables', {}, {}, [
+            ['string', {name: 'id'}, {}, '']
+          ]]
+        }, [
+        ['dataStructure', {}, {}, [
+          ['string', {name: 'id'}, {}, null],
+          ['string', {name: 'tag'}, {}, null]
+        ]],
+        ['transition', {}, {}, [
+          ['httpTransaction', {title: 'Get a frob', description: 'Gets information about a single frob instance'}, {}, [
+            ['httpRequest', {}, {method: 'GET'}, null],
+            ['httpResponse', {}, {statusCode: 200, headers: ['httpHeaders', {}, {}, [
+              ['string', {name: 'Content-Type'}, {}, 'application/json']
+            ]]}, [
+              ['asset', {'class': ['messageBody']}, {}, '{\n  "id": "1",\n  "tag": "foo"\n}\n']
+            ]]
+          ]]
+        ]]
+      ]]
+    ]]
+  ]
+];
+
 describe('Nodes.js require', () => {
   it('should work without needing to use `.default`', () => {
     assert(require('../../lib/fury').parse);
@@ -108,34 +137,7 @@ describe('Refract loader', () => {
     let api;
 
     before(() => {
-      api = fury.load([
-        'category', {'class': ['api'], 'title': 'My API'}, {}, [
-          ['category', {'class': ['resourceGroup'], title: 'My Group'}, {}, [
-            ['copy', {}, {contentType: 'text/plain'}, 'Extra text'],
-            ['resource', {title: 'Frob'}, {
-              href: '/frobs/{id}',
-              hrefVariables: ['hrefVariables', {}, {}, [
-                  ['string', {name: 'id'}, {}, '']
-                ]]
-              }, [
-              ['dataStructure', {}, {}, [
-                ['string', {name: 'id'}, {}, null],
-                ['string', {name: 'tag'}, {}, null]
-              ]],
-              ['transition', {}, {}, [
-                ['httpTransaction', {}, {}, [
-                  ['httpRequest', {}, {}, null],
-                  ['httpResponse', {}, {statusCode: 200, headers: ['httpHeaders', {}, {}, [
-                    ['string', {name: 'Content-Type'}, {}, 'application/json']
-                  ]]}, [
-                    ['asset', {'class': 'messageBody'}, {}, '{"id": "1", "tag": "foo"}']
-                  ]]
-                ]]
-              ]]
-            ]]
-          ]]
-        ]
-      ]);
+      api = fury.load(refractedApi);
     });
 
     it('should parse a refract shorthand API', () => {

--- a/test/integration/serializer-test.es6
+++ b/test/integration/serializer-test.es6
@@ -29,7 +29,7 @@ describe('Serializers', () => {
 
           fury.serialize({api: refract, mediaType: 'text/vnd.apiblueprint'}, (serializeErr, serialized) => {
             if (serializeErr) { return done(serializeErr); }
-            assert.deepEqual(serialized.trim(), expectedBlueprint.trim());
+            assert.deepEqual(expectedBlueprint.trim(), serialized.trim());
             done();
           });
         });

--- a/test/integration/serializer-test.es6
+++ b/test/integration/serializer-test.es6
@@ -1,0 +1,39 @@
+import {assert} from 'chai';
+import fs from 'fs';
+import glob from 'glob';
+import fury from '../../lib/fury';
+import path from 'path';
+
+const base = path.join(__dirname, 'serializers');
+
+describe('Serializers', () => {
+  const files = glob.sync(path.join(base, '*.json'));
+
+  files.forEach((file) => {
+    describe(path.basename(file), () => {
+      const apib = file.substr(0, file.length - 4) + 'apib';
+
+      if (fs.existsSync(apib)) {
+        it('should convert to API Blueprint', (done) => {
+          let serializedRefract;
+          let expectedBlueprint;
+          let refract;
+
+          try {
+            serializedRefract = require(file);
+            expectedBlueprint = fs.readFileSync(apib, 'utf-8');
+            refract = fury.load(serializedRefract);
+          } catch (loadErr) {
+            return done(loadErr);
+          }
+
+          fury.serialize({api: refract, mediaType: 'text/vnd.apiblueprint'}, (serializeErr, serialized) => {
+            if (serializeErr) { return done(serializeErr); }
+            assert.deepEqual(serialized.trim(), expectedBlueprint.trim());
+            done();
+          });
+        });
+      }
+    });
+  });
+});

--- a/test/integration/serializers/basic.apib
+++ b/test/integration/serializers/basic.apib
@@ -1,0 +1,11 @@
+FORMAT: 1A
+
+# My API
+
+#### GET /message
+
++ Response 200 (text/plain)
+
+    + Body
+
+            Hello, World!

--- a/test/integration/serializers/basic.apib
+++ b/test/integration/serializers/basic.apib
@@ -6,6 +6,4 @@ FORMAT: 1A
 
 + Response 200 (text/plain)
 
-    + Body
-
-            Hello, World!
+        Hello, World!

--- a/test/integration/serializers/basic.json
+++ b/test/integration/serializers/basic.json
@@ -1,0 +1,16 @@
+[
+  "category", {"title": "My API"}, {}, [
+    ["resource", {}, {}, [
+      ["transition", {}, {}, [
+        ["httpTransaction", {}, {}, [
+          ["httpRequest", {}, {"method": "GET", "href": "/message"}, null],
+          ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
+            ["string", {"name": "Content-Type"}, {}, "text/plain"]
+          ]]}, [
+            ["asset", {"class": ["messageBody"]}, {}, "Hello, World!"]
+          ]]
+        ]]
+      ]]
+    ]]
+  ]
+]

--- a/test/integration/serializers/sample.apib
+++ b/test/integration/serializers/sample.apib
@@ -1,0 +1,24 @@
+FORMAT: 1A
+
+# My API
+
+An API description.
+
+## Group My Group
+
+This is a group of resources
+
+### Frob (/frobs/{id})
+
+A frob does something.
+
+#### GET
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+              "id": "1",
+              "tag": "foo"
+            }

--- a/test/integration/serializers/sample.apib
+++ b/test/integration/serializers/sample.apib
@@ -8,17 +8,39 @@ An API description.
 
 This is a group of resources
 
-### Frob (/frobs/{id})
+### Frob [/frobs/{id}]
 
 A frob does something.
+
++ Parameters
+
+    + id (required) - Unique identifier
 
 #### GET
 
 + Response 200 (application/json)
+
+    + Headers
+
+            Authorization: Bearer abc123
 
     + Body
 
             {
               "id": "1",
               "tag": "foo"
+            }
+
+    + Schema
+
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
             }

--- a/test/integration/serializers/sample.apib
+++ b/test/integration/serializers/sample.apib
@@ -20,6 +20,8 @@ A frob does something.
 
 #### GET
 
++ Relation: Frob
+
 + Response 200 (application/json)
 
     + Headers

--- a/test/integration/serializers/sample.apib
+++ b/test/integration/serializers/sample.apib
@@ -8,6 +8,8 @@ An API description.
 
 This is a group of resources
 
+Extra text
+
 ### Frob [/frobs/{id}]
 
 A frob does something.

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -1,0 +1,28 @@
+[
+  "category", {"class": ["api"], "title": "My API", "description": "An API description."}, {}, [
+    ["category", {"class": ["resourceGroup"], "title": "My Group", "description": "This is a group of resources"}, {}, [
+      ["copy", {}, {"contentType": "text/plain"}, "Extra text"],
+      ["resource", {"title": "Frob", "description": "A frob does something."}, {
+        "href": "/frobs/{id}",
+        "hrefVariables": ["hrefVariables", {}, {}, [
+            ["string", {"name": "id"}, {}, ""]
+          ]]
+        }, [
+        ["dataStructure", {}, {}, [
+          ["string", {"name": "id"}, {}, null],
+          ["string", {"name": "tag"}, {}, null]
+        ]],
+        ["transition", {}, {}, [
+          ["httpTransaction", {"title": "Get a frob", "description": "Gets information about a single frob instance"}, {}, [
+            ["httpRequest", {}, {"method": "GET"}, null],
+            ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
+              ["string", {"name": "Content-Type"}, {}, "application/json"]
+            ]]}, [
+              ["asset", {"class": ["messageBody"]}, {}, "{\n  \"id\": \"1\",\n  \"tag\": \"foo\"\n}\n"]
+            ]]
+          ]]
+        ]]
+      ]]
+    ]]
+  ]
+]

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -5,7 +5,10 @@
       ["resource", {"title": "Frob", "description": "A frob does something."}, {
         "href": "/frobs/{id}",
         "hrefVariables": ["hrefVariables", {}, {}, [
-            ["string", {"name": "id", "description": "Unique identifier"}, {"typeAttributes": ["required"]}, ""]
+            ["member", {}, {}, {
+              "key": ["string", {}, {}, "id"],
+              "value": ["string", {"description": "Unique identifier"}, {"typeAttributes": ["required"]}, ""]
+            }]
           ]]
         }, [
         ["dataStructure", {}, {}, [

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -5,7 +5,7 @@
       ["resource", {"title": "Frob", "description": "A frob does something."}, {
         "href": "/frobs/{id}",
         "hrefVariables": ["hrefVariables", {}, {}, [
-            ["string", {"name": "id"}, {}, ""]
+            ["string", {"name": "id", "description": "Unique identifier"}, {"typeAttributes": ["required"]}, ""]
           ]]
         }, [
         ["dataStructure", {}, {}, [
@@ -16,9 +16,11 @@
           ["httpTransaction", {"title": "Get a frob", "description": "Gets information about a single frob instance"}, {}, [
             ["httpRequest", {}, {"method": "GET"}, null],
             ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
-              ["string", {"name": "Content-Type"}, {}, "application/json"]
+              ["string", {"name": "Content-Type"}, {}, "application/json"],
+              ["string", {"name": "Authorization"}, {}, "Bearer abc123"]
             ]]}, [
-              ["asset", {"class": ["messageBody"]}, {}, "{\n  \"id\": \"1\",\n  \"tag\": \"foo\"\n}\n"]
+              ["asset", {"class": ["messageBody"]}, {}, "{\n  \"id\": \"1\",\n  \"tag\": \"foo\"\n}\n"],
+              ["asset", {"class": ["messageBodySchema"]}, {}, "{\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"string\"\n    },\n    \"tag\": {\n      \"type\": \"string\"\n    }\n  }\n}"]
             ]]
           ]]
         ]]

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -12,7 +12,7 @@
           ["string", {"name": "id"}, {}, null],
           ["string", {"name": "tag"}, {}, null]
         ]],
-        ["transition", {}, {}, [
+        ["transition", {}, {"relation": "Frob"}, [
           ["httpTransaction", {"title": "Get a frob", "description": "Gets information about a single frob instance"}, {}, [
             ["httpRequest", {}, {"method": "GET"}, null],
             ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -5,9 +5,9 @@
       ["resource", {"title": "Frob", "description": "A frob does something."}, {
         "href": "/frobs/{id}",
         "hrefVariables": ["hrefVariables", {}, {}, [
-            ["member", {}, {}, {
+            ["member", {}, {"typeAttributes": ["required"]}, {
               "key": ["string", {}, {}, "id"],
-              "value": ["string", {"description": "Unique identifier"}, {"typeAttributes": ["required"]}, ""]
+              "value": ["string", {"description": "Unique identifier"}, {}, ""]
             }]
           ]]
         }, [


### PR DESCRIPTION
This PR adds a serializer that outputs API Blueprint when given as input
a refract element type instance. Included are a couple of serializer
tests that show both the input and output.

Currently supported:
- API
- Copy
- Resource group
- Resource
  - Parameters
  - Relation
- Transition
  - Parameters
- HTTP transaction
- HTTP request
- HTTP response
- Asset (message body + schema)

It is implemented using the [Swig](http://paularmstrong.github.io/swig/)
template system. Jade is too HTML specific, and EJS had issues with whitespace,
which is crucial for Markdown-based formats like API Blueprint. Anybody who
has used Django, Jinja, Liquid, etc should feel right at home. Because
whitespace is so important, the template doesn't look particularly pretty :sob:

cc @smizell @zdne 
