### PR TITLE
Support parsers returning element instances.

### DIFF
--- a/src/fury.es6
+++ b/src/fury.es6
@@ -69,7 +69,14 @@ class Fury {
       adapter.parse({source, generateSourceMap}, (err, elements) => {
         if (err) { return done(err); }
 
-        done(null, this.load(elements));
+        let loaded;
+        if (elements instanceof minim.ElementType) {
+          loaded = elements;
+        } else {
+          loaded = this.load(elements);
+        }
+
+        done(null, loaded);
       });
     } else {
       done(new Error('Document did not match any registered adapter!'));

--- a/src/fury.es6
+++ b/src/fury.es6
@@ -69,14 +69,11 @@ class Fury {
       adapter.parse({source, generateSourceMap}, (err, elements) => {
         if (err) { return done(err); }
 
-        let loaded;
         if (elements instanceof minim.ElementType) {
-          loaded = elements;
+          done(null, elements);
         } else {
-          loaded = this.load(elements);
+          done(null, this.load(elements));
         }
-
-        done(null, loaded);
       });
     } else {
       done(new Error('Document did not match any registered adapter!'));

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -2,6 +2,7 @@ import {assert} from 'chai';
 import fury, {
   Fury, legacyBlueprintParser, legacyMarkdownRenderer
 } from '../../lib/fury';
+import minim from 'minim';
 
 const refractedApi = [
   'category', {'class': ['api'], title: 'My API', description: 'An API description.'}, {}, [
@@ -102,6 +103,17 @@ describe('Parser', () => {
     });
 
     it('should parse through autodetect', (done) => {
+      fury.parse({source: 'dummy'}, (err, api) => {
+        assert.equal(api.content, 'dummy');
+        done(err);
+      });
+    });
+
+    it('should parse when returning element instances', (done) => {
+      // Modify the parse method to return an element instance
+      fury.adapters[fury.adapters.length - 1].parse = ({source}, cb) =>
+        cb(null, new minim.StringType(source));
+
       fury.parse({source: 'dummy'}, (err, api) => {
         assert.equal(api.content, 'dummy');
         done(err);


### PR DESCRIPTION
Before this, parsers were expected to always return serialized refract. Now,
both forms of serialized refract (normal + shorthand) _and_ element instances
are supported, so if your serializer converts to element instances you no
longer need the round-trip to serialize/load.

cc @smizell 
