### PR TITLE
Initial support for Swagger 2.0 WIP

### DIFF
--- a/src/adapters/swagger20.es6
+++ b/src/adapters/swagger20.es6
@@ -1,0 +1,149 @@
+import _ from 'underscore';
+
+import { registry, MemberType } from 'minim';
+import '../refract/api';
+
+// Define API Description elements
+const Category = registry.getElementClass('category');
+const Resource = registry.getElementClass('resource');
+const Transition = registry.getElementClass('transition');
+const HttpTransaction = registry.getElementClass('httpTransaction');
+const HttpRequest = registry.getElementClass('httpRequest');
+const HttpResponse = registry.getElementClass('httpResponse');
+const HrefVariables = registry.getElementClass('hrefVariables');
+const Asset = registry.getElementClass('asset');
+
+export const name = 'swagger20';
+
+// TODO: Figure out media type for Swagger 2.0
+export const mediaTypes = ['application/swagger+json'];
+
+export function detect(source) {
+  return source.swagger === '2.0';
+}
+
+/*
+ * Parse Swagger 2.0 into Refract elements
+ */
+export function parse({ source }, done) {
+  // TODO: Will refactor this once API Description namespace is stable
+  // Leaving as large block of code until then
+  let basePath = source.basePath || '';
+  let schemaDefinitions = _.pick(source, 'definitions') || {};
+
+  let api = new Category();
+
+  // Root API Element
+  api.meta.class.push('api');
+  api.meta.title.set(source.info.title);
+  api.meta.description.set(source.info.description);
+
+  // Swagger has a paths object to loop through
+  // The key is the href
+  _.each(source.paths, (pathValue, href) => {
+    let resource = new Resource();
+    api.content.push(resource);
+
+    // TODO: Better title and description for the resources
+    // For now, give a title of the HREF
+    resource.meta.title.set('Resource ' + href);
+
+    // Each path is an object with methods as properties
+    _.each(pathValue, (methodValue, method) => {
+      let methodValueParameters = methodValue.parameters || [];
+
+      let queryParameters = methodValueParameters.filter((parameter) => {
+        return parameter.in === 'query';
+      });
+
+      // URI parameters are for query and path variables
+      let uriParameters = methodValueParameters.filter((parameter) => {
+        return parameter.in === 'query' || parameter.in === 'path';
+      });
+
+      // Body parameters are ones that define JSON Schema
+      let bodyParameter = _.first(
+        methodValueParameters.filter((parameter) => {
+          return parameter.in === 'body';
+        })
+      );
+
+      // Query parameters are added the HREF if they exist
+      if (queryParameters.length > 0) {
+        let queryParameterNames = queryParameters.map((parameter) => {
+          return parameter.name;
+        });
+
+        resource.attributes.href = basePath + href + '{?' + queryParameterNames.join(',') + '}';
+      } else {
+        resource.attributes.href = href;
+      }
+
+      // For each uriParameter, create an hrefVariable
+      if (uriParameters.length > 0) {
+        resource.hrefVariables = new HrefVariables();
+
+        _.each(queryParameters, (parameter) => {
+          // TODO: allow for multiple types
+          // Currently only allows for strings
+          let member = new MemberType(parameter.name, '');
+          resource.hrefVariables.content.push(member);
+
+          if (parameter.required) {
+            member.attributes.typeAttributes = ['required'];
+          }
+        });
+      }
+
+      let transition = new Transition();
+      resource.content.push(transition);
+
+      transition.meta.description.set(methodValue.summary);
+      transition.meta.title.set(methodValue.operationId);
+
+      let schemaAsset;
+
+      // Body parameters define schema
+      if (bodyParameter) {
+        schemaAsset = new Asset(JSON.stringify(_.extend({}, bodyParameter.schema, schemaDefinitions)));
+        schemaAsset.meta.class.push('messageBodySchema');
+        schemaAsset.attributes.contentType = 'application/schema+json';
+      }
+
+      // Transactions are created for each response in the document
+      _.each(methodValue.responses, (responseValue, statusCode) => {
+        let transaction = new HttpTransaction();
+        transition.content.push(transaction);
+
+        let request = new HttpRequest();
+        let response = new HttpResponse();
+        transaction.content = [request, response];
+
+        request.attributes.method = method.toUpperCase();
+
+        if (schemaAsset) {
+          request.content.push(schemaAsset);
+        }
+
+        // TODO: Decide what to do with request hrefs
+        // If the URI is templated, we don't want to add it to the request
+        // if (uriParameters.length === 0) {
+        //   request.attributes.href = href;
+        // }
+
+        response.attributes.statusCode = statusCode;
+      });
+    });
+  });
+
+  done(null, api);
+}
+
+
+/*
+ * Serialize an API into Swagger 2.0.
+ */
+export function serialize({ api }, done) {
+  // TODO: Implement Swagger 2.0 serializer
+  done(new Error('Not implemented yet!'));
+}

--- a/src/fury.es6
+++ b/src/fury.es6
@@ -1,5 +1,6 @@
 import minim from 'minim';
 import * as apiBlueprintAdapter from './adapters/api-blueprint';
+import * as swagger20Adapter from './adapters/swagger20';
 
 // Legacy imports
 import legacyAPI from './legacy/blueprint';
@@ -24,6 +25,7 @@ function findAdapter(adapters, mediaType) {
 class Fury {
   constructor() {
     this.adapters = [
+      swagger20Adapter,
       apiBlueprintAdapter
     ];
   }

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -186,6 +186,11 @@ export class HttpRequest extends HttpMessagePayload {
 }
 
 export class HttpResponse extends HttpMessagePayload {
+  constructor(...args) {
+    super(...args);
+    this.element = 'httpResponse';
+  }
+
   get statusCode() {
     return this.attributes.statusCode;
   }

--- a/test/fixtures/adapters/swagger20/api-description-example.json
+++ b/test/fixtures/adapters/swagger20/api-description-example.json
@@ -1,0 +1,1228 @@
+{
+  "element": "category",
+  "meta": {
+    "class": [
+      "api"
+    ],
+    "title": "Swagger Sample App",
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger \n    at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.  For this sample,\n    you can use the api key \"special-key\" to test the authorization filters"
+  },
+  "attributes": {},
+  "content": [
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /pet"
+      },
+      "attributes": {
+        "href": "/pet"
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Update an existing pet",
+            "title": "updatePet"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "PUT"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"$ref\":\"#/definitions/Pet\",\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            },
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "PUT"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"$ref\":\"#/definitions/Pet\",\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "404"
+                  },
+                  "content": []
+                }
+              ]
+            },
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "PUT"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"$ref\":\"#/definitions/Pet\",\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "405"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /pet/findByStatus"
+      },
+      "attributes": {
+        "href": "/api/pet/findByStatus{?status}",
+        "hrefVariables": {
+          "element": "hrefVariables",
+          "meta": {},
+          "attributes": {},
+          "content": [
+            {
+              "element": "member",
+              "attributes": {
+                "typeAttributes": [
+                  "required"
+                ]
+              },
+              "meta": {},
+              "content": {
+                "key": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "status"
+                },
+                "value": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": ""
+                }
+              }
+            }
+          ]
+        }
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Finds Pets by status",
+            "title": "findPetsByStatus"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /pet/findByTags"
+      },
+      "attributes": {
+        "href": "/api/pet/findByTags{?tags}",
+        "hrefVariables": {
+          "element": "hrefVariables",
+          "meta": {},
+          "attributes": {},
+          "content": [
+            {
+              "element": "member",
+              "attributes": {
+                "typeAttributes": [
+                  "required"
+                ]
+              },
+              "meta": {},
+              "content": {
+                "key": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "tags"
+                },
+                "value": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": ""
+                }
+              }
+            }
+          ]
+        }
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Finds Pets by tags",
+            "title": "findPetsByTags"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /pet/{petId}"
+      },
+      "attributes": {
+        "href": "/pet/{petId}",
+        "hrefVariables": {
+          "element": "hrefVariables",
+          "meta": {},
+          "attributes": {},
+          "content": []
+        }
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Updates a pet in the store with form data",
+            "title": "updatePetWithForm"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "POST"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "405"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Find pet by ID",
+            "title": "getPetById"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            },
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "404"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Deletes a pet",
+            "title": "deletePet"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "DELETE"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "transition",
+          "meta": {
+            "description": "partial updates to a pet",
+            "title": "partialUpdate"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "PATCH"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"$ref\":\"#/definitions/Pet\",\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /pet/uploadImage"
+      },
+      "attributes": {
+        "href": "/pet/uploadImage"
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "uploads an image",
+            "title": "uploadFile"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "POST"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "200"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /user/createWithArray"
+      },
+      "attributes": {
+        "href": "/user/createWithArray"
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Creates list of users with given input array",
+            "title": "createUsersWithArrayInput"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "POST"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "200"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /user/createWithList"
+      },
+      "attributes": {
+        "href": "/user/createWithList"
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Creates list of users with given list input",
+            "title": "createUsersWithListInput"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "POST"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "200"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /user/{username}"
+      },
+      "attributes": {
+        "href": "/user/{username}",
+        "hrefVariables": {
+          "element": "hrefVariables",
+          "meta": {},
+          "attributes": {},
+          "content": []
+        }
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Updated user",
+            "title": "updateUser"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "PUT"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"$ref\":\"#/definitions/User\",\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            },
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "PUT"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"$ref\":\"#/definitions/User\",\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "404"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Delete user",
+            "title": "deleteUser"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "DELETE"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            },
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "DELETE"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "404"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Get user by user name",
+            "title": "getUserByName"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            },
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "404"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /user/login"
+      },
+      "attributes": {
+        "href": "/api/user/login{?username,password}",
+        "hrefVariables": {
+          "element": "hrefVariables",
+          "meta": {},
+          "attributes": {},
+          "content": [
+            {
+              "element": "member",
+              "attributes": {
+                "typeAttributes": [
+                  "required"
+                ]
+              },
+              "meta": {},
+              "content": {
+                "key": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "username"
+                },
+                "value": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": ""
+                }
+              }
+            },
+            {
+              "element": "member",
+              "attributes": {
+                "typeAttributes": [
+                  "required"
+                ]
+              },
+              "meta": {},
+              "content": {
+                "key": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "password"
+                },
+                "value": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": ""
+                }
+              }
+            }
+          ]
+        }
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Logs user into the system",
+            "title": "loginUser"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /user/logout"
+      },
+      "attributes": {
+        "href": "/user/logout"
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Logs out current logged in user session",
+            "title": "logoutUser"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "200"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /user"
+      },
+      "attributes": {
+        "href": "/user"
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Create user",
+            "title": "createUser"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "POST"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"$ref\":\"#/definitions/User\",\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "200"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /store/order"
+      },
+      "attributes": {
+        "href": "/store/order"
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Place an order for a pet",
+            "title": "placeOrder"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "POST"
+                  },
+                  "content": [
+                    {
+                      "element": "asset",
+                      "meta": {
+                        "class": [
+                          "messageBodySchema"
+                        ]
+                      },
+                      "attributes": {
+                        "contentType": "application/schema+json"
+                      },
+                      "content": "{\"$ref\":\"#/definitions/Order\",\"definitions\":{\"Tag\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Pet\":{\"required\":[\"id\",\"name\"],\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\",\"description\":\"unique identifier for the pet\",\"minimum\":0,\"maximum\":100,\"default\":-1},\"category\":{\"$ref\":\"#/definitions/Category\"},\"name\":{\"type\":\"string\"},\"photoUrls\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"tags\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/Tag\"}},\"status\":{\"type\":\"string\",\"description\":\"pet status in the store\",\"enum\":[\"available\",\"pending\",\"sold\"]}}},\"Category\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"name\":{\"type\":\"string\"}}},\"Animal\":{\"required\":[\"id\",\"type\"],\"properties\":{\"id\":{\"type\":\"long\"},\"type\":{\"type\":\"string\"}},\"discriminator\":\"type\"},\"Cat\":{\"required\":[\"likesMilk\"],\"properties\":{\"likesMilk\":{\"type\":\"boolean\"}},\"allOf\":[{\"$ref\":\"#/definitions/Animal\"}]},\"User\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"firstName\":{\"type\":\"string\"},\"username\":{\"type\":\"string\"},\"lastName\":{\"type\":\"string\"},\"email\":{\"type\":\"string\"},\"password\":{\"type\":\"string\"},\"phone\":{\"type\":\"string\"},\"userStatus\":{\"type\":\"integer\",\"format\":\"int32\",\"description\":\"User Status\",\"enum\":[\"1-registered\",\"2-active\",\"3-closed\"]}}},\"Order\":{\"properties\":{\"id\":{\"type\":\"integer\",\"format\":\"int64\"},\"petId\":{\"type\":\"integer\",\"format\":\"int64\"},\"quantity\":{\"type\":\"integer\",\"format\":\"int32\"},\"status\":{\"type\":\"string\",\"description\":\"Order Status\",\"enum\":[\"placed\",\" approved\",\" delivered\"]},\"shipDate\":{\"type\":\"string\",\"format\":\"date-time\"}}}}}"
+                    }
+                  ]
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /store/order/{orderId}"
+      },
+      "attributes": {
+        "href": "/store/order/{orderId}",
+        "hrefVariables": {
+          "element": "hrefVariables",
+          "meta": {},
+          "attributes": {},
+          "content": []
+        }
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Delete purchase order by ID",
+            "title": "deleteOrder"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "DELETE"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            },
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "DELETE"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "404"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Find purchase order by ID",
+            "title": "getOrderById"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "400"
+                  },
+                  "content": []
+                }
+              ]
+            },
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {
+                    "statusCode": "404"
+                  },
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/adapters/swagger20/swagger-2.0-example.json
+++ b/test/fixtures/adapters/swagger20/swagger-2.0-example.json
@@ -1,0 +1,750 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Sample App",
+        "description": "This is a sample server Petstore server.  You can find out more about Swagger \n    at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.  For this sample,\n    you can use the api key \"special-key\" to test the authorization filters",
+        "contact": {
+            "email": "apiteam@wordnik.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        },
+        "termsOfService": "http://helloreverb.com/terms/"
+    },
+    "paths": {
+        "/pet": {
+            "put": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    },
+                    "405": {
+                        "description": "Validation exception"
+                    }
+                },
+                "description": "",
+                "summary": "Update an existing pet",
+                "operationId": "updatePet",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/plain",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "Pet object that needs to be updated in the store",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    }
+                ]
+            }
+        },
+        "/pet/findByStatus": {
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid status value"
+                    }
+                },
+                "description": "",
+                "summary": "Finds Pets by status",
+                "operationId": "findPetsByStatus",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/plain",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "Status values that need to be considered for filter",
+                        "name": "status",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        "/pet/findByTags": {
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid tag value"
+                    }
+                },
+                "description": "",
+                "summary": "Finds Pets by tags",
+                "operationId": "findPetsByTags",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/plain",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "Tags to filter by",
+                        "name": "tags",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        "/pet/{petId}": {
+            "post": {
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "description": "",
+                "summary": "Updates a pet in the store with form data",
+                "operationId": "updatePetWithForm",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/plain",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of pet that needs to be updated",
+                        "name": "petId",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "formData",
+                        "description": "Updated name of the pet",
+                        "name": "name",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "formData",
+                        "description": "Updated status of the pet",
+                        "name": "status",
+                        "required": false,
+                        "type": "string"
+                    }
+                ]
+            },
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    }
+                },
+                "description": "",
+                "summary": "Find pet by ID",
+                "operationId": "getPetById",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/plain",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of pet that needs to be fetched",
+                        "name": "petId",
+                        "required": true,
+                        "type": "integer",
+                        "default": -1,
+                        "maximum": 100000,
+                        "minimum": 1
+                    }
+                ]
+            },
+            "delete": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid pet value"
+                    }
+                },
+                "description": "",
+                "summary": "Deletes a pet",
+                "operationId": "deletePet",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/plain",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "Pet id to delete",
+                        "name": "petId",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            },
+            "patch": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid tag value"
+                    }
+                },
+                "description": "",
+                "summary": "partial updates to a pet",
+                "operationId": "partialUpdate",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/plain",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of pet that needs to be fetched",
+                        "name": "petId",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "description": "Pet object that needs to be added to the store",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    }
+                ]
+            }
+        },
+        "/pet/uploadImage": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "No response was specified"
+                    }
+                },
+                "description": "",
+                "summary": "uploads an image",
+                "operationId": "uploadFile",
+                "produces": [
+                    "application/json",
+                    "application/xml",
+                    "text/plain",
+                    "text/html"
+                ],
+                "parameters": [
+                    {
+                        "in": "formData",
+                        "description": "Additional data to pass to server",
+                        "name": "additionalMetadata",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "formData",
+                        "description": "file to upload",
+                        "name": "file",
+                        "required": false,
+                        "type": "file"
+                    }
+                ]
+            }
+        },
+        "/user/createWithArray": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "No response was specified"
+                    }
+                },
+                "description": "",
+                "summary": "Creates list of users with given input array",
+                "operationId": "createUsersWithArrayInput",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "List of user object",
+                        "name": "body",
+                        "required": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/User"
+                        }
+                    }
+                ]
+            }
+        },
+        "/user/createWithList": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "No response was specified"
+                    }
+                },
+                "description": "",
+                "summary": "Creates list of users with given list input",
+                "operationId": "createUsersWithListInput",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "List of user object",
+                        "name": "body",
+                        "required": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/User"
+                        }
+                    }
+                ]
+            }
+        },
+        "/user/{username}": {
+            "put": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                },
+                "description": "",
+                "summary": "Updated user",
+                "operationId": "updateUser",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "name that need to be deleted",
+                        "name": "username",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "description": "Updated user object",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/User"
+                        }
+                    }
+                ]
+            },
+            "delete": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                },
+                "description": "",
+                "summary": "Delete user",
+                "operationId": "deleteUser",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "The name that needs to be deleted",
+                        "name": "username",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            },
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                },
+                "description": "",
+                "summary": "Get user by user name",
+                "operationId": "getUserByName",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "The name that needs to be fetched. Use user1 for testing.",
+                        "name": "username",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        "/user/login": {
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid username and password combination"
+                    }
+                },
+                "description": "",
+                "summary": "Logs user into the system",
+                "operationId": "loginUser",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "The user name for login",
+                        "name": "username",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "description": "The password for login in clear text",
+                        "name": "password",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        "/user/logout": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "No response was specified"
+                    }
+                },
+                "description": "",
+                "summary": "Logs out current logged in user session",
+                "operationId": "logoutUser",
+                "produces": [
+                    "application/json"
+                ]
+            }
+        },
+        "/user": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "No response was specified"
+                    }
+                },
+                "description": "",
+                "summary": "Create user",
+                "operationId": "createUser",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "Created user object",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/User"
+                        }
+                    }
+                ]
+            }
+        },
+        "/store/order": {
+            "post": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid order"
+                    }
+                },
+                "description": "",
+                "summary": "Place an order for a pet",
+                "operationId": "placeOrder",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "description": "order placed for purchasing the pet",
+                        "name": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    }
+                ]
+            }
+        },
+        "/store/order/{orderId}": {
+            "delete": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                },
+                "description": "",
+                "summary": "Delete purchase order by ID",
+                "operationId": "deleteOrder",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of the order that needs to be deleted",
+                        "name": "orderId",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            },
+            "get": {
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                },
+                "description": "",
+                "summary": "Find purchase order by ID",
+                "operationId": "getOrderById",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "description": "ID of pet that needs to be fetched",
+                        "name": "orderId",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            }
+        }
+    },
+    "securityDefinitions": {
+        "oauth2_implicit": {
+            "type": "oauth2",
+            "flow": "implicit",
+            "authorizationUrl": "http://petstore.swagger.wordnik.com/api/oauth/dialog",
+            "scopes": {
+                "write:pets": "Modify pets in your account",
+                "read:pets": "Read your pets"
+            }
+        },
+        "oauth2_authorization_code": {
+            "type": "oauth2",
+            "flow": "accessCode",
+            "authorizationUrl": "http://petstore.swagger.wordnik.com/api/oauth/requestToken",
+            "tokenUrl": "http://petstore.swagger.wordnik.com/api/oauth/token",
+            "scopes": {
+                "write:pets": "Modify pets in your account",
+                "read:pets": "Read your pets"
+            }
+        }
+    },
+    "host": "petstore.swagger.wordnik.com",
+    "basePath": "/api",
+    "schemes": [
+        "http"
+    ],
+    "definitions": {
+        "Tag": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "Pet": {
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "unique identifier for the pet",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "default": -1
+                },
+                "category": {
+                    "$ref": "#/definitions/Category"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "photoUrls": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                },
+                "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": [
+                        "available",
+                        "pending",
+                        "sold"
+                    ]
+                }
+            }
+        },
+        "Category": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "Animal": {
+            "required": [
+                "id",
+                "type"
+            ],
+            "properties": {
+                "id": {
+                    "type": "long"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "discriminator": "type"
+        },
+        "Cat": {
+            "required": [
+                "likesMilk"
+            ],
+            "properties": {
+                "likesMilk": {
+                    "type": "boolean"
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Animal"
+                }
+            ]
+        },
+        "User": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "userStatus": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "User Status",
+                    "enum": [
+                        "1-registered",
+                        "2-active",
+                        "3-closed"
+                    ]
+                }
+            }
+        },
+        "Order": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "petId": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "quantity": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Order Status",
+                    "enum": [
+                        "placed",
+                        " approved",
+                        " delivered"
+                    ]
+                },
+                "shipDate": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        }
+    }
+}

--- a/test/integration/adapters/swagger20-test.es6
+++ b/test/integration/adapters/swagger20-test.es6
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+
+import { assert } from 'chai';
+
+import fury from '../../../lib/fury';
+
+const base = path.join(__dirname, '../../fixtures/adapters/swagger20');
+
+const swagger20ExampleFile = fs.readFileSync(path.join(base, 'swagger-2.0-example.json'), 'utf8');
+const swagger20Example = JSON.parse(swagger20ExampleFile);
+
+const apiDescriptionExampleFile = fs.readFileSync(path.join(base, 'api-description-example.json'), 'utf8');
+const apiDescriptionExample = JSON.parse(apiDescriptionExampleFile, 'utf8');
+
+describe('Swagger 2.0 Integration', () => {
+  let apiDescription;
+
+  before((done) => {
+    fury.parse({ source: swagger20Example }, (error, refract) => {
+      apiDescription = refract.toRefract();
+      done(error);
+    });
+  });
+
+  it('correctly parses a Swagger 2.0 document', () => {
+    assert.deepEqual(apiDescription, apiDescriptionExample);
+  });
+});

--- a/test/unit/adapters/swagger20-test.es6
+++ b/test/unit/adapters/swagger20-test.es6
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+
+import { assert } from 'chai';
+import * as swagger20Adapter from '../../../lib/adapters/swagger20';
+
+const base = path.join(__dirname, '../../fixtures/adapters/swagger20');
+
+const swagger20ExampleFile = fs.readFileSync(path.join(base, 'swagger-2.0-example.json'), 'utf8');
+const swagger20Example = JSON.parse(swagger20ExampleFile);
+
+const apiDescriptionExampleFile = fs.readFileSync(path.join(base, 'api-description-example.json'), 'utf8');
+const apiDescriptionExample = JSON.parse(apiDescriptionExampleFile);
+
+describe('Swagger Adapter', () => {
+  it('has the correct name', () => {
+    assert.equal(swagger20Adapter.name, 'swagger20');
+  });
+
+  it('correct detects a Swagger 2.0 document', () => {
+    assert.isTrue(swagger20Adapter.detect(swagger20Example));
+  });
+
+  context('when parsing a Swagger 2.0 document', () => {
+    let parsedDocument;
+
+    before((done) => {
+      swagger20Adapter.parse({ source: swagger20Example }, (error, apiDescription) => {
+        parsedDocument = apiDescription.toRefract();
+        done(error);
+      });
+    });
+
+    it('correctly parses the document', () => {
+      assert.deepEqual(parsedDocument, apiDescriptionExample)
+    });
+  });
+});


### PR DESCRIPTION
This provides an adapter for parsing Swagger 2.0 documents. It is currently
incomplete as it does not provide full support for paramters. It also needs
more testing to ensure it correctly defines data, specifically schemas.

Additionally, this is relying on the current API Description and Resource
Description namespaces of Refract, which may be changing soon. I have left the
code fairly verbose and non-modular at this point so I can easily change it if
we make changes.
