### PR TITLE
Add support for MSON serialization.

### DIFF
--- a/src/adapters/api-blueprint.es6
+++ b/src/adapters/api-blueprint.es6
@@ -1,4 +1,5 @@
 import Drafter from 'drafter';
+import mson from './mson';
 import path from 'path';
 import swig from 'swig';
 
@@ -76,6 +77,7 @@ function pretty(input) {
   return prettified;
 }
 
+swig.setFilter('mson', mson);
 swig.setFilter('indent', indent);
 swig.setFilter('bodyOnly', bodyOnly);
 swig.setFilter('resourceShorthand', resourceShorthand);

--- a/src/adapters/mson.es6
+++ b/src/adapters/mson.es6
@@ -1,0 +1,131 @@
+/*
+ * Renders refract elements into MSON.
+ */
+
+/*
+ * Indent a piece of multiline text by a number of spaces.
+ */
+function indent(input, spaces) {
+   let pre = '';
+   let lines = [];
+
+   for (let _ = 0; _ < spaces; _++) {
+     pre += ' ';
+   }
+
+   for (let line of input.split('\n')) {
+     // Only indent non-blank lines!
+     lines.push(line ? pre + line : line);
+   }
+
+   return lines.join('\n').trim();
+ }
+
+/*
+ * Get type information for an element, such as the element name, whether
+ * it is required, etc. Returns an array of strings.
+ */
+function getTypeAttributes(element, attributes={}) {
+  let typeAttributes = [];
+
+  if (element.element !== 'string' && element.element !== 'dataStructure') {
+    typeAttributes.push(element.element);
+  }
+
+  return typeAttributes.concat(attributes.typeAttributes || []);
+}
+
+/*
+ * Handle the rendering of an element based on its element type. This function
+ * will call itself recursively to handle child elements for objects and
+ * arrays.
+ */
+function handle(name, element, {parent=null, spaces=4, marker='+',
+                                initialMarker='+',
+                                initialIndent=true,
+                                attributesElement=element}) {
+  const elementName = element.element;
+  let str = initialMarker;
+
+  // Start with the item name if it has one.
+  if (name) {
+    str += ` ${name}`;
+  }
+
+  // Next, comes the optional example value
+  if (typeof element.content !== 'object') {
+    if (parent && parent.element !== 'array') {
+      str += ':';
+    }
+    str += ` ${element.content}`;
+  }
+
+  // Then the type and attribute information (e.g. required)
+  let attributes = getTypeAttributes(element, attributesElement.attributes);
+  if (attributes.length) {
+    str += ` (${attributes.join(', ')})`;
+  }
+
+  // Finally, an optional description
+  if (attributesElement.attributes &&
+      attributesElement.attributes.description) {
+    // TODO: Handle multiline or very long descriptions
+    str += ` - ${attributesElement.attributes.description}`;
+  }
+
+  // TODO: Handle default, sample, and other special array items here,
+  //       keeping in mind that they force extra indentation below as well
+  //       as the use of special values like `+ Properties`.
+
+  // Now, depending on the content type, we will recursively handle child
+  // elements within objects and arrays.
+  if (element.content && element.content.length) {
+    str += '\n';
+
+    if (elementName === 'dataStructure') {
+      str += '\n';
+    }
+
+    for (let item of element.content) {
+      // Note: the `initialIndent` option above works because we specifically
+      //       do *not* pass it down the rabbit hole here.
+      if (item.element === 'member') {
+        // This is an object type or something similar.
+        str += handle(item.key.content, item.value, {
+          parent: element,
+          spaces,
+          marker,
+          attributesElement: item
+        });
+      } else {
+        // This is an array type or something similar.
+        str += handle(item.meta.title.toValue(), item, {
+          parent: element,
+          spaces,
+          marker
+        });
+      }
+    }
+  }
+
+  // Return the entire block indented to the correct number of spaces.
+  if (initialIndent) {
+    str = indent(str, spaces);
+  }
+
+  return str + '\n';
+}
+
+/*
+ * Render out a piece of MSON from refract element instances.
+ */
+export default function render(mson) {
+  // Render *either* ### Title or + Attributes as the base element to support
+  // both a data structures section and resource / payload attributes.
+  const title = mson.meta.title.toValue();
+
+  return handle(title || 'Attributes', mson, {
+    initialMarker: title ? '###' : '+',
+    initialIndent: title ? false : true
+  });
+}

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -357,4 +357,5 @@ registry
   .register('hrefVariables', HrefVariables)
   .register('asset', Asset)
   .register('httpRequest', HttpRequest)
-  .register('httpResponse', HttpResponse);
+  .register('httpResponse', HttpResponse)
+  .register('dataStructure', DataStructure);

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -17,6 +17,9 @@ FORMAT: 1A
       {% endfor %}
 
   {% endif %}
+  {% if example.dataStructure %}
+    {{ example.dataStructure|mson|indent(4) }}
+  {% endif %}
   {% if example.messageBody %}
     + Body
 
@@ -108,6 +111,9 @@ FORMAT: 1A
 {% if resource.hrefVariables.length %}
 {{ renderParameters(resource.hrefVariables) }}
 {% endif %}
+{% if resource.dataStructure %}
+{{ resource.dataStructure|mson }}
+{% endif %}
 {% for transition in resource.transitions.content %}
   {{ renderTransition(transition, href) }}
 {% endfor %}
@@ -129,14 +135,30 @@ FORMAT: 1A
 
 
 
+{% macro renderDataStructures(dataStructures) %}
+## Data Structures
+
+{% for dataStructure in dataStructures.content %}
+{{ dataStructure|mson }}
+{% endfor %}
+{% endmacro %}
+
+
+
+
+
+
 {% macro renderCategory(category) %}
   {# Categories can contain copy (text) elements, other categories, and resources #}
   {% for item in category.content %}
     {% if item.element === 'copy' %}
 {{ item.content }}
     {% endif %}
-    {% if item.element === 'category' && item.meta.class.indexOf('resourceGroup') !== -1 %}
+    {% if item.element === 'category' && item.meta.class.contains('resourceGroup') %}
       {{ renderGroup(item) }}
+    {% endif %}
+    {% if item.element === 'category' && item.meta.class.contains('dataStructure') %}
+      {{ renderDataStructures(item) }}
     {% endif %}
     {% if item.element === 'resource' %}
       {{ renderResource(item) }}

--- a/test/integration/serializers/sample.apib
+++ b/test/integration/serializers/sample.apib
@@ -18,6 +18,14 @@ A frob does something.
 
     + id (required) - Unique identifier
 
++ Attributes
+
+    + id (required)
+    + tags (array)
+        + (object)
+            + name (required)
+            + count: 23 (number)
+
 #### GET
 
 + Relation: Frob
@@ -32,7 +40,12 @@ A frob does something.
 
             {
               "id": "1",
-              "tag": "foo"
+              "tags": [
+                {
+                  "name": "foo",
+                  "count": 23
+                }
+              ]
             }
 
     + Schema
@@ -43,8 +56,14 @@ A frob does something.
                 "id": {
                   "type": "string"
                 },
-                "tag": {
-                  "type": "string"
+                "tags": {
+                  "type": "array"
                 }
               }
             }
+
+## Data Structures
+
+### User
+
++ name (required)

--- a/test/integration/serializers/sample.apib
+++ b/test/integration/serializers/sample.apib
@@ -23,8 +23,19 @@ A frob does something.
     + id (required)
     + tags (array)
         + (object)
-            + name (required)
-            + count: 23 (number)
+            Describes a tag.
+
+            Each tag has a name and a number of times it was used.
+
+            + Properties
+                + name (required) - Tag name.
+                + count: 23 (number)
+                    I am some long content.
+
+                    - one
+                    - two
+
+                    + Default: 1
 
 #### GET
 

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -12,8 +12,25 @@
           ]]
         }, [
         ["dataStructure", {}, {}, [
-          ["string", {"name": "id"}, {}, null],
-          ["string", {"name": "tag"}, {}, null]
+          ["member", {}, {"typeAttributes": ["required"]}, {
+            "key": ["string", {}, {}, "id"],
+            "value": ["string", {}, {}, null]
+          }],
+          ["member", {}, {}, {
+            "key": ["string", {}, {}, "tags"],
+            "value": ["array", {}, {}, [
+                ["object", {}, {}, [
+                  ["member", {}, {"typeAttributes": ["required"]}, {
+                    "key": ["string", {}, {}, "name"],
+                    "value": ["string", {}, {}, null]
+                  }],
+                  ["member", {}, {}, {
+                    "key": ["string", {}, {}, "count"],
+                    "value": ["number", {}, {}, 23]
+                  }]
+                ]]
+            ]]
+          }]
         ]],
         ["transition", {}, {"relation": "Frob"}, [
           ["httpTransaction", {"title": "Get a frob", "description": "Gets information about a single frob instance"}, {}, [
@@ -22,11 +39,19 @@
               ["string", {"name": "Content-Type"}, {}, "application/json"],
               ["string", {"name": "Authorization"}, {}, "Bearer abc123"]
             ]]}, [
-              ["asset", {"class": ["messageBody"]}, {}, "{\n  \"id\": \"1\",\n  \"tag\": \"foo\"\n}\n"],
-              ["asset", {"class": ["messageBodySchema"]}, {}, "{\"type\": \"object\",  \"properties\": {\"id\": {\"type\": \"string\"},\"tag\": {      \"type\": \"string\"}}}"]
+              ["asset", {"class": ["messageBody"]}, {}, "{\n  \"id\": \"1\",\n  \"tags\": [\n    {\n      \"name\": \"foo\",\n      \"count\": 23\n    }\n  ]\n}\n"],
+              ["asset", {"class": ["messageBodySchema"]}, {}, "{\"type\": \"object\",  \"properties\": {\"id\": {\"type\": \"string\"},\"tags\": {      \"type\": \"array\"}}}"]
             ]]
           ]]
         ]]
+      ]]
+    ]],
+    ["category", {"class": ["dataStructure"]}, {}, [
+      ["dataStructure", {"title": "User"}, {}, [
+        ["member", {}, {"typeAttributes": ["required"]}, {
+          "key": ["string", {}, {}, "name"],
+          "value": ["string", {}, {}, null]
+        }]
       ]]
     ]]
   ]

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -19,14 +19,14 @@
           ["member", {}, {}, {
             "key": ["string", {}, {}, "tags"],
             "value": ["array", {}, {}, [
-                ["object", {}, {}, [
-                  ["member", {}, {"typeAttributes": ["required"]}, {
+                ["object", {"description": "Describes a tag.\n\nEach tag has a name and a number of times it was used."}, {}, [
+                  ["member", {"description": "Tag name."}, {"typeAttributes": ["required"]}, {
                     "key": ["string", {}, {}, "name"],
                     "value": ["string", {}, {}, null]
                   }],
-                  ["member", {}, {}, {
+                  ["member", {"description": "I am some long content.\n\n- one\n- two\n"}, {}, {
                     "key": ["string", {}, {}, "count"],
-                    "value": ["number", {}, {}, 23]
+                    "value": ["number", {}, {"default": 1}, 23]
                   }]
                 ]]
             ]]


### PR DESCRIPTION
This PR adds support to serialize from refract element instances into MSON within an API Blueprint, and adds the feature to the API Blueprint serializer. Not everything is supported yet, but a significant portion of the spec is, including defaults, samples, multiline descriptions, inheritance, includes, and data structures. See the updated `sample.json`/`sample.apib` for an example. This is the same technology that was included in the reveal demo but has several added features.

The `extends` and `select` (One Of) elements aren't yet supported and depend on upstream implementation before they can be serialized here.

Note that this is **not** implemented in a Swig template, or any template format. This is due to the recursive nature and indentation of the format. I tried several approaches and scrapped them before settling on this approach. I am worried about the maintainability of the codebase, so any suggestions are welcome.

cc @zdne @smizell 
