### PR TITLE
Prepare for 0.8.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.8.0 - 12 June 2015
+
+- Expose a new [Refract][]-based interface through `fury.parse`, `fury.load`,
+  and `fury.serialize`. This is a *work in progress*.
+- Add a Swagger parser.
+- Add an API Blueprint serializer with basic MSON support.
+- Update the codebase to make use of ES6 features.
+
+[Refract]: https://github.com/refractproject/refract-spec

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "description": "API Description SDK",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./lib/fury",
   "repository": {
@@ -12,9 +12,7 @@
     "node": ">= 0.10.x"
   },
   "scripts": {
-    "lint": "eslint --ext .js,.es6 src",
-    "precompile": "npm run lint",
-    "compile": "babel src --out-dir lib && coffee -b -c -o lib/ src/",
+    "compile": "eslint --ext .js,.es6 src && babel src --optional runtime --out-dir lib && coffee -b -c -o lib/ src/",
     "precoverage": "npm run compile",
     "coverage": "istanbul cover _mocha -- --compilers es6:babel/register,coffee:coffee-script/register -R spec --recursive",
     "precoveralls": "npm run coverage",
@@ -25,6 +23,7 @@
   },
   "dependencies": {
     "apiary-blueprint-parser": "",
+    "babel-runtime": "^5.5.6",
     "drafter": "^0.2.5",
     "minim": "^0.5.0",
     "robotskirt": "",


### PR DESCRIPTION
- Depend on `babel-runtime` to support downstream environments without `Symbol`
- Minor optimization to spawn one fewer `npm` instance on build.
- Bump the version.

Tests pass and I'm able to use this in a downstream project locally with `npm link`. Everything should be ready to be released! Keep in mind this still requires Node.js 0.10.x and does not (yet) work on newer versions.
