### PR TITLE
Add support for parameters found in paths object in Swagger

### DIFF
--- a/test/fixtures/adapters/swagger20/api-description-example.json
+++ b/test/fixtures/adapters/swagger20/api-description-example.json
@@ -180,7 +180,39 @@
         "title": "Resource /pet/findByStatus"
       },
       "attributes": {
-        "href": "/api/pet/findByStatus{?status}"
+        "href": "/api/pet/findByStatus{?status}",
+        "hrefVariables": {
+          "element": "hrefVariables",
+          "meta": {},
+          "attributes": {},
+          "content": [
+            {
+              "element": "member",
+              "attributes": {
+                "typeAttributes": [
+                  "required"
+                ]
+              },
+              "meta": {
+                "description": "Status values that need to be considered for filter"
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "status"
+                },
+                "value": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": ""
+                }
+              }
+            }
+          ]
+        }
       },
       "content": [
         {

--- a/test/fixtures/adapters/swagger20/swagger-2.0-example.json
+++ b/test/fixtures/adapters/swagger20/swagger-2.0-example.json
@@ -105,7 +105,16 @@
                         "type": "string"
                     }
                 ]
-            }
+            },
+            "parameters": [
+                {
+                    "in": "query",
+                    "description": "Status values that need to be considered for filter",
+                    "name": "status",
+                    "required": true,
+                    "type": "string"
+                }
+            ]
         },
         "/pet/findByTags": {
             "get": {


### PR DESCRIPTION
Per the current Swagger 2.0 docs:

https://github.com/swagger-api/swagger-spec/blob/8b2467daf0a3c6def8bfad095d67964d64f060ae/versions/2.0.md#fixed-fields-4

You can define parameters in the Paths Object. This PR provides support for
query and path variables.
