### PR TITLE
Update to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.1 - 19 June 2015
 
 - Better parameter support for Swagger parser. (#26)
 - Dereferncing of local references in JSON Schemas (#27)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "description": "API Description SDK",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./lib/fury",
   "repository": {


### PR DESCRIPTION
Release the Fury 0.8.1

Includes better parameter support for Swagger and dereferenced JSON Schemas.
