### PR TITLE
Reduce new lines in parameter/header sections in serialisation

### DIFF
--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -13,8 +13,7 @@ FORMAT: 1A
     + Headers
 
       {% for header in example.headers.exclude('Content-Type').content %}
-            {{ header.meta.getProperty('name').content }}: {{ header.content }}
-      {% endfor %}
+            {{ header.meta.getProperty('name').content }}: {{ header.content }}{% endfor %}
 
   {% endif %}
   {% if example.dataStructure %}
@@ -44,8 +43,7 @@ FORMAT: 1A
 + Parameters
 
   {% for item in hrefVariables.content %}
-    + {{ item.key.toValue() }}{% if item.attributes.typeAttributes %} ({{ item.attributes.typeAttributes }}){% endif %}{% if item.value.meta.description.toValue() %} - {{ item.value.meta.description.toValue() }}{% endif %}
-  {% endfor %}
+    + {{ item.key.toValue() }}{% if item.attributes.typeAttributes %} ({{ item.attributes.typeAttributes }}){% endif %}{% if item.value.meta.description.toValue() %} - {{ item.value.meta.description.toValue() }}{% endif %}{% endfor %}
 
 {% endmacro %}
 


### PR DESCRIPTION
I would appreciate if someone could test this, I'm unable to get it working since i don't have an older version of node.js compatible with robotskirt and I'd rather not mess with my node.js install since it will probably result in breaking other things.

My intention is to remove extra newlines in parameters and headers, turning:

``` apib
+ Parameter

    1

    2
```

Into:

``` apib
+ Parameter

    1
    2
```
