### PR TITLE
Add support for arrays in query parameters

### DIFF
--- a/src/adapters/swagger20.es6
+++ b/src/adapters/swagger20.es6
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import deref from 'json-schema-deref-sync';
 
-import { registry, MemberType, BooleanType, NumberType, StringType } from 'minim';
+import { registry, MemberType, BooleanType, NumberType, StringType, ArrayType } from 'minim';
 import '../refract/api';
 
 // Define API Description elements
@@ -33,6 +33,11 @@ function convertParameterToElement(parameter) {
     memberValue = new NumberType();
   } else if (parameter.type === 'boolean') {
     memberValue = new BooleanType();
+  } else if (parameter.type === 'array') {
+    memberValue = new ArrayType();
+  } else {
+    // Default to a string in case we get a type we haven't seen
+    memberValue = new StringType('');
   }
 
   // TODO: Update when Minim has better support for elements as values
@@ -44,6 +49,12 @@ function convertParameterToElement(parameter) {
 
   if (parameter.required) {
     member.attributes.typeAttributes = ['required'];
+  }
+
+  // If there is a default, it is set on the member value instead of the member
+  // element itself because the default value applies to the value.
+  if (parameter.default) {
+    memberValue.attributes.default = parameter.default;
   }
 
   return member;

--- a/test/fixtures/adapters/swagger20/api-description-example.json
+++ b/test/fixtures/adapters/swagger20/api-description-example.json
@@ -245,10 +245,10 @@
                       "content": "status"
                     },
                     "value": {
-                      "element": "string",
+                      "element": "array",
                       "meta": {},
                       "attributes": {},
-                      "content": ""
+                      "content": []
                     }
                   }
                 }
@@ -325,7 +325,7 @@
         "title": "Resource /pet/findByTags"
       },
       "attributes": {
-        "href": "/api/pet/findByTags{?tags}"
+        "href": "/api/pet/findByTags{?tags,unknown}"
       },
       "content": [
         {
@@ -356,6 +356,31 @@
                       "meta": {},
                       "attributes": {},
                       "content": "tags"
+                    },
+                    "value": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {},
+                      "content": ""
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "attributes": {
+                    "typeAttributes": [
+                      "required"
+                    ]
+                  },
+                  "meta": {
+                    "description": "For tests. Unknown type of query parameter."
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {},
+                      "content": "unknown"
                     },
                     "value": {
                       "element": "string",
@@ -562,7 +587,9 @@
                     "value": {
                       "element": "number",
                       "meta": {},
-                      "attributes": {},
+                      "attributes": {
+                        "default": 1
+                      },
                       "content": null
                     }
                   }

--- a/test/fixtures/adapters/swagger20/swagger-2.0-example.json
+++ b/test/fixtures/adapters/swagger20/swagger-2.0-example.json
@@ -101,11 +101,21 @@
                 ],
                 "parameters": [
                     {
+                        "name": "status",
                         "in": "query",
                         "description": "Status values that need to be considered for filter",
-                        "name": "status",
                         "required": true,
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                        "type": "string",
+                        "enum": [
+                          "available",
+                          "pending",
+                          "sold"
+                        ],
+                        "default": "available"
+                        },
+                        "collectionFormat": "csv"
                     }
                 ]
             },
@@ -154,6 +164,13 @@
                         "name": "tags",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "description": "For tests. Unknown type of query parameter.",
+                        "name": "unknown",
+                        "required": true,
+                        "type": "unknown"
                     }
                 ]
             }


### PR DESCRIPTION
This adds support for handling arrays as query parameters. It only sets the type as array, but does not handle any of the item data associated with the array.
