### PR TITLE
Fix parsing of empty responses in Swagger

### DIFF
--- a/test/fixtures/adapters/swagger20/api-description-example.json
+++ b/test/fixtures/adapters/swagger20/api-description-example.json
@@ -12,6 +12,90 @@
     {
       "element": "resource",
       "meta": {
+        "title": "Resource /empty-responses"
+      },
+      "attributes": {
+        "href": "/empty-responses"
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Empty responses",
+            "title": "emptyResponses"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {},
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
+        "title": "Resource /only-default-response"
+      },
+      "attributes": {
+        "href": "/only-default-response"
+      },
+      "content": [
+        {
+          "element": "transition",
+          "meta": {
+            "description": "Only default response set",
+            "title": "onlyDefaultResponse"
+          },
+          "attributes": {},
+          "content": [
+            {
+              "element": "httpTransaction",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpRequest",
+                  "meta": {},
+                  "attributes": {
+                    "method": "GET"
+                  },
+                  "content": []
+                },
+                {
+                  "element": "httpResponse",
+                  "meta": {},
+                  "attributes": {},
+                  "content": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "resource",
+      "meta": {
         "title": "Resource /pet"
       },
       "attributes": {

--- a/test/fixtures/adapters/swagger20/swagger-2.0-example.json
+++ b/test/fixtures/adapters/swagger20/swagger-2.0-example.json
@@ -27,6 +27,25 @@
         "name": "store"
     }],
     "paths": {
+        "/empty-responses": {
+            "get": {
+                "description": "Empty responses",
+                "summary": "",
+                "operationId": "emptyResponses"
+            }
+        },
+        "/only-default-response": {
+            "get": {
+                "responses": {
+                    "default": {
+                        "description": "Unexpected error"
+                    }
+                },
+                "description": "Only default response set",
+                "summary": "",
+                "operationId": "onlyDefaultResponse"
+            }
+        },
         "/pet": {
             "put": {
                 "responses": {


### PR DESCRIPTION
This fixes an issue where the adapter would not parse HTTP methods if there were empty or only default response. This adds code to add request and empty response.

Note: I added an empty response because the spec requires a transaction to have a request and response.
