### PR TITLE
Do not write response when there is empty response

### DIFF
--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -57,8 +57,8 @@ FORMAT: 1A
 + Request{% if transaction.request.contentType %} ({{ transaction.request.contentType }}){% endif %}
 {{ renderExample(transaction.request) }}
 {% endif %}
-{% if transaction.response %}
-+ Response{% if transaction.response.statusCode %} {{ transaction.response.statusCode }}{% endif %}{% if transaction.response.contentType %} ({{ transaction.response.contentType }}){% endif %}
+{% if transaction.response && transaction.response.statusCode %}
++ Response {{ transaction.response.statusCode }}{% if transaction.response.contentType %} ({{ transaction.response.contentType }}){% endif %}
 {{ renderExample(transaction.response) }}
 {% endif %}
 {% endmacro %}

--- a/test/integration/serializers/sample.apib
+++ b/test/integration/serializers/sample.apib
@@ -73,6 +73,12 @@ A frob does something.
               }
             }
 
+#### Restart a frob [POST]
+
+Restart a frob instance
+
++ Relation: restart
+
 ## Data Structures
 
 ### User

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -43,6 +43,12 @@
               ["asset", {"class": ["messageBodySchema"]}, {}, "{\"type\": \"object\",  \"properties\": {\"id\": {\"type\": \"string\"},\"tags\": {      \"type\": \"array\"}}}"]
             ]]
           ]]
+        ]],
+        ["transition", {"title": "Restart a frob", "description": "Restart a frob instance"}, {"relation": "restart"}, [
+          ["httpTransaction", {}, {}, [
+            ["httpRequest", {}, {"method": "POST"}, []],
+            ["httpResponse", {}, {}, []]
+          ]]
         ]]
       ]]
     ]],


### PR DESCRIPTION
This PR makes sure that when there is an empty response, API Blueprint serializer does not write anything related to the response.
