### PR TITLE
Update to Minim 0.9.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-runtime": "^5.5.6",
     "drafter": "^0.2.5",
     "json-schema-deref-sync": "^0.1.1",
-    "minim": "^0.5.0",
+    "minim": "^0.8.0",
     "robotskirt": "",
     "sanitizer": "",
     "swig": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-runtime": "^5.5.6",
     "drafter": "^0.2.5",
     "json-schema-deref-sync": "^0.1.1",
-    "minim": "^0.8.0",
+    "minim": "^0.9.0",
     "robotskirt": "",
     "sanitizer": "",
     "swig": "^1.4.2",

--- a/src/fury.es6
+++ b/src/fury.es6
@@ -71,7 +71,7 @@ class Fury {
       adapter.parse({source, generateSourceMap}, (err, elements) => {
         if (err) { return done(err); }
 
-        if (elements instanceof minim.ElementType) {
+        if (elements instanceof minim.BaseElement) {
           done(null, elements);
         } else {
           done(null, this.load(elements));

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -58,12 +58,12 @@ export class Asset extends BaseElement {
     this.element = 'asset';
   }
 
-  get contentElement() {
-    return this.attributes.getValue('contentElement');
+  get contentType() {
+    return this.attributes.getValue('contentType');
   }
 
-  set contentElement(value) {
-    this.attributes.set('contentElement', value);
+  set contentType(value) {
+    this.attributes.set('contentType', value);
   }
 
   get href() {

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -20,39 +20,11 @@
  */
 
 import {
-  ArrayType, attributeElementKeys, ElementType, ObjectType, StringType,
-  registry
+  ArrayElement, BaseElement, ObjectElement, StringElement, registry
 } from 'minim';
 import {filterBy} from './util';
 
-/*
- * A base element which provides some conveniences for all API-related
- * elements.
- */
-class ApiBaseArray extends ArrayType {
-  get title() {
-    return this.meta.title && this.meta.title.toValue();
-  }
-
-  set title(value) {
-    this.meta.title = value;
-  }
-
-  get description() {
-    return this.meta.description && this.meta.description.toValue();
-  }
-
-  set description(value) {
-    this.meta.description = value;
-  }
-
-  hasClass(name) {
-    return this.meta && this.meta.class && this.meta.class.indexOf &&
-           this.meta.class.indexOf(name) !== -1;
-  }
-}
-
-class HttpHeaders extends ApiBaseArray {
+class HttpHeaders extends ArrayElement {
   constructor(...args) {
     super(...args);
     this.element = 'httpHeaders';
@@ -60,67 +32,65 @@ class HttpHeaders extends ApiBaseArray {
 
   exclude(name) {
     return this.filter(item => {
-      let itemName = item.meta.getProperty('name');
+      let itemName = item.name;
 
       if (!itemName) {
         // This can't possibly match, so we include it in the results.
         return true;
       }
 
-      // Note: this may not be a string, hence the duck-type check below!
-      itemName = itemName.toValue();
+      // Note: this may not be a string, hence the duck-Element check below!
       return !(itemName.toLowerCase) || itemName.toLowerCase() !== name.toLowerCase();
     });
   }
 }
 
-class HrefVariables extends ObjectType {
+class HrefVariables extends ObjectElement {
   constructor(...args) {
     super(...args);
     this.element = 'hrefVariables';
   }
 }
 
-export class Asset extends ElementType {
+export class Asset extends BaseElement {
   constructor(...args) {
     super(...args);
     this.element = 'asset';
   }
 
-  get contentType() {
-    return this.attributes.contentType;
+  get contentElement() {
+    return this.attributes.getValue('contentElement');
   }
 
-  set contentType(value) {
-    this.attributes.contentType = value;
+  set contentElement(value) {
+    this.attributes.set('contentElement', value);
   }
 
   get href() {
-    return this.attributes.href;
+    return this.attributes.getValue('href');
   }
 
   set href(value) {
-    this.attributes.href = value;
+    this.attributes.set('href', value);
   }
 }
 
-class HttpMessagePayload extends ApiBaseArray {
+class HttpMessagePayload extends ArrayElement {
   constructor(...args) {
     super(...args);
-
-    this[attributeElementKeys] = ['headers'];
+    this._attributeElementKeys = ['headers'];
   }
 
   get headers() {
-    return this.attributes.headers;
+    return this.attributes.get('headers');
   }
 
   set headers(value) {
-    this.attributes.headers = value;
+    this.attributes.set('headers', value);
   }
 
   header(name) {
-    const headers = this.attributes.headers;
+    const headers = this.attributes.get('headers');
     let header = null;
 
     if (headers) {
@@ -128,9 +98,13 @@ class HttpMessagePayload extends ApiBaseArray {
         name,
         ignoreCase: true
       }))[0];
+
+      if (header) {
+        header = header.toValue();
+      }
     }
 
-    return header ? header.content : header;
+    return header;
   }
 
   get contentType() {
@@ -142,14 +116,14 @@ class HttpMessagePayload extends ApiBaseArray {
   }
 
   get dataStructure() {
-    return this.filter(item => item.element === 'dataStructure').first();
+    return this.findByElement('dataStructure').first();
   }
 
   get messageBody() {
     // Returns the *first* message body. Only one should be defined according
     // to the spec, but it's possible to include more.
     return this.filter((item) => {
-      return item.element === 'asset' && item.meta.class.contains('messageBody');
+      return item.element === 'asset' && item.class.contains('messageBody');
     }).first();
   }
 
@@ -157,7 +131,7 @@ class HttpMessagePayload extends ApiBaseArray {
     // Returns the *first* message body schema. Only one should be defined
     // according to the spec, but it's possible to include more.
     return this.filter((item) => {
-      return item.element === 'asset' && item.meta.class.contains('messageBodySchema');
+      return item.element === 'asset' && item.class.contains('messageBodySchema');
     }).first();
   }
 }
@@ -169,19 +143,19 @@ export class HttpRequest extends HttpMessagePayload {
   }
 
   get method() {
-    return this.attributes.method;
+    return this.attributes.getValue('method');
   }
 
   set method(value) {
-    this.attributes.method = value;
+    this.attributes.set('method', value);
   }
 
   get href() {
-    return this.attributes.href;
+    return this.attributes.getValue('href');
   }
 
   set href(value) {
-    this.attributes.href = value;
+    this.attributes.set('href', value);
   }
 }
 
@@ -192,51 +166,55 @@ export class HttpResponse extends HttpMessagePayload {
   }
 
   get statusCode() {
-    return this.attributes.statusCode;
+    return this.attributes.getValue('statusCode');
   }
 
   set statusCode(value) {
-    this.attributes.statusCode = value;
+    this.attributes.set('statusCode', value);
   }
 }
 
-export class HttpTransaction extends ApiBaseArray {
+export class HttpTransaction extends ArrayElement {
   constructor(...args) {
     super(...args);
     this.element = 'httpTransaction';
   }
 
   get request() {
-    return this.filter(item => item.element === 'httpRequest').first();
+    return this.findByElement('httpRequest').first();
   }
 
   get response() {
-    return this.filter(item => item.element === 'httpResponse').first();
+    return this.findByElement('httpResponse').first();
   }
 }
 
-export class Transition extends ApiBaseArray {
+export class Transition extends ArrayElement {
   constructor(...args) {
     super(...args);
 
     this.element = 'transition';
-    this[attributeElementKeys] = ['parameters', 'attributes'];
+    this._attributeElementKeys = ['parameters', 'attributes'];
+  }
+
+  get method() {
+    return this.transactions.get(0).request.method;
   }
 
   get relation() {
-    return this.attributes.relation;
+    return this.attributes.getValue('relation');
   }
 
   set relation(value) {
-    this.attributes.relation = value;
+    this.attributes.set('relation', value);
   }
 
   get href() {
-    return this.attributes.href;
+    return this.attributes.getValue('href');
   }
 
   set href(value) {
-    this.attributes.href = value;
+    this.attributes.set('href', value);
   }
 
   get computedHref() {
@@ -248,68 +226,68 @@ export class Transition extends ApiBaseArray {
   }
 
   get parameters() {
-    return this.attributes.parameters;
+    return this.attributes.get('parameters');
   }
 
   set parameters(value) {
-    this.attributes.parameters = value;
+    this.attributes.set('parameters', value);
   }
 
   // The key `attributes` is already taken, so `attr` is used instead.
   get attr() {
-    return this.attributes.attributes;
+    return this.attributes.get('attributes');
   }
 
   set attr(value) {
-    this.attributes.attributes = value;
+    this.attributes.set('attributes', value);
   }
 
   get transactions() {
-    return this.filter(item => item.element === 'httpTransaction');
+    return this.findByElement('httpTransaction');
   }
 }
 
-export class Resource extends ApiBaseArray {
+export class Resource extends ArrayElement {
   constructor(...args) {
     super(...args);
 
     this.element = 'resource';
-    this[attributeElementKeys] = ['hrefVariables'];
+    this._attributeElementKeys = ['hrefVariables'];
   }
 
   get href() {
-    return this.attributes.href;
+    return this.attributes.getValue('href');
   }
 
   set href(value) {
-    this.attributes.href = value;
+    this.attributes.set('href', value);
   }
 
   get hrefVariables() {
-    return this.attributes.hrefVariables;
+    return this.attributes.get('hrefVariables');
   }
 
   set hrefVariables(value) {
-    this.attributes.hrefVariables = value;
+    this.attributes.set('hrefVariables', value);
   }
 
   get transitions() {
-    return this.filter(item => item.element === 'transition');
+    return this.findByElement('transition');
   }
 
   get dataStructure() {
-    return this.filter(item => item.element === 'dataStructure').first();
+    return this.findByElement('dataStructure').first();
   }
 }
 
-export class DataStructure extends ObjectType {
+export class DataStructure extends ObjectElement {
   constructor(...args) {
     super(...args);
     this.element = 'dataStructure';
   }
 }
 
-export class Copy extends StringType {
+export class Copy extends StringElement {
   constructor(...args) {
     super(...args);
     this.element = 'copy';
@@ -320,38 +298,38 @@ export class Copy extends StringType {
   }
 
   set contentType(value) {
-    this.attributes.contentType = value;
+    this.attributes.set('contentType', value);
   }
 }
 
-export class Category extends ApiBaseArray {
+export class Category extends ArrayElement {
   constructor(...args) {
     super(...args);
     this.element = 'category';
   }
 
   get resourceGroups() {
-    return this.filter(item => item.meta.class.contains('resourceGroup'));
+    return this.findByClass('resourceGroup');
   }
 
   get dataStructures() {
-    return this.filter(item => item.meta.class.contains('dataStructures'));
+    return this.findByClass('dataStructures');
   }
 
   get scenarios() {
-    return this.filter(item => item.meta.class.contains('scenario'));
+    return this.findByClass('scenario');
   }
 
   get resources() {
-    return this.filter(item => item.element === 'resource');
+    return this.findByElement('resource');
   }
 
   get copy() {
-    return this.filter(item => item.element === 'copy');
+    return this.findByElement('copy');
   }
 }
 
-// Register the API and Resource element types.
+// Register the API and Resource element Elements.
 registry
   .register('category', Category)
   .register('copy', Copy)

--- a/src/refract/util.es6
+++ b/src/refract/util.es6
@@ -19,13 +19,15 @@ export function filterBy(options, item) {
   if (options.element && item.element !== options.element) {
     return false;
   }
-  if (options.name && item.meta.name) {
+
+  let name = item.name;
+  if (options.name && name) {
     if (options.ignoreCase) {
-      if (item.meta.name.toLowerCase() !== options.name.toLowerCase()) {
+      if (name.toLowerCase() !== options.name.toLowerCase()) {
         return false;
       }
     } else {
-      if (item.meta.name !== options.name) {
+      if (name !== options.name) {
         return false;
       }
     }

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -13,7 +13,7 @@ FORMAT: 1A
     + Headers
 
       {% for header in example.headers.exclude('Content-Type').content %}
-            {{ header.meta.getProperty('name').content }}: {{ header.content }}{% endfor %}
+            {{ header.name }}: {{ header.content }}{% endfor %}
 
   {% endif %}
   {% if example.dataStructure %}
@@ -43,7 +43,8 @@ FORMAT: 1A
 + Parameters
 
   {% for item in hrefVariables.content %}
-    + {{ item.key.toValue() }}{% if item.attributes.typeAttributes %} ({{ item.attributes.typeAttributes }}){% endif %}{% if item.value.meta.description.toValue() %} - {{ item.value.meta.description.toValue() }}{% endif %}{% endfor %}
+    {% set typeAttributes = item.attributes.get('typeAttributes') %}
+    + {{ item.key.toValue() }}{% if typeAttributes %} ({{ typeAttributes.toValue() }}){% endif %}{% if item.value.description %} - {{ item.value.description }}{% endif %}{% endfor %}
 
 {% endmacro %}
 
@@ -53,13 +54,15 @@ FORMAT: 1A
 
 
 {% macro renderTransaction(transaction) %}
-{% if transaction.request && (transaction.request.contentType || transaction.request.headers || transaction.request.dataStructure || transaction.request.messageBody || transaction.request.messageBodySchema) %}
-+ Request{% if transaction.request.contentType %} ({{ transaction.request.contentType }}){% endif %}
-{{ renderExample(transaction.request) }}
+{% set request = transaction.request %}
+{% set response = transaction.response %}
+{% if request && (request.contentType || request.headers || request.dataStructure || request.messageBody || request.messageBodySchema) %}
++ Request{% if request.contentType %} ({{ request.contentType }}){% endif %}
+{{ renderExample(request) }}
 {% endif %}
-{% if transaction.response && transaction.response.statusCode %}
-+ Response {{ transaction.response.statusCode }}{% if transaction.response.contentType %} ({{ transaction.response.contentType }}){% endif %}
-{{ renderExample(transaction.response) }}
+{% if response && response.statusCode %}
++ Response {{ response.statusCode }}{% if response.contentType %} ({{ response.contentType }}){% endif %}
+{{ renderExample(response) }}
 {% endif %}
 {% endmacro %}
 
@@ -69,9 +72,9 @@ FORMAT: 1A
 
 {% macro renderTransition(transition, href) %}
 {% if transition.title %}
-#### {{ transition.title }} [{{ transition.transactions.get(0).request.method }}{% if href %} {{ href }}{% elseif transition.computedHref %} {{ transition.computedHref }}{% endif %}]
+#### {{ transition.title }} [{{ transition.method }}{% if href %} {{ href }}{% elseif transition.computedHref %} {{ transition.computedHref }}{% endif %}]
 {% else %}
-#### {{ transition.transactions.get(0).request.method }}{% if href %} {{ href }}{% elseif transition.computedHref %} {{ transition.computedHref }}{% endif %}
+#### {{ transition.method }}{% if href %} {{ href }}{% elseif transition.computedHref %} {{ transition.computedHref }}{% endif %}
 {% endif %}
 
 {{ transition.description }}
@@ -152,10 +155,10 @@ FORMAT: 1A
     {% if item.element === 'copy' %}
 {{ item.content }}
     {% endif %}
-    {% if item.element === 'category' && item.meta.class.contains('resourceGroup') %}
+    {% if item.element === 'category' && item.class.contains('resourceGroup') %}
       {{ renderGroup(item) }}
     {% endif %}
-    {% if item.element === 'category' && item.meta.class.contains('dataStructure') %}
+    {% if item.element === 'category' && item.class.contains('dataStructure') %}
       {{ renderDataStructures(item) }}
     {% endif %}
     {% if item.element === 'resource' %}

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -18,8 +18,14 @@ const refractedApi = [
         ]]
         }, [
         ['dataStructure', {}, {}, [
-          ['string', {name: 'id'}, {}, null],
-          ['string', {name: 'tag'}, {}, null]
+          ["member", {}, {"typeAttributes": ["required"]}, {
+            "key": ["string", {}, {}, "id"],
+            "value": ["string", {}, {}, null]
+          }],
+          ["member", {}, {}, {
+            "key": ["string", {}, {}, "tag"],
+            "value": ["string", {}, {}, null]
+          }]
         ]],
         ['transition', {}, {}, [
           ['httpTransaction', {title: 'Get a frob', description: 'Gets information about a single frob instance'}, {}, [

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -112,7 +112,7 @@ describe('Parser', () => {
     it('should parse when returning element instances', (done) => {
       // Modify the parse method to return an element instance
       fury.adapters[fury.adapters.length - 1].parse = ({source}, cb) =>
-        cb(null, new minim.StringType(source));
+        cb(null, new minim.StringElement(source));
 
       fury.parse({source: 'dummy'}, (err, api) => {
         assert.equal(api.content, 'dummy');
@@ -212,7 +212,7 @@ describe('Refract loader', () => {
       const response = resource.transitions.get(0).transactions.get(0).response;
 
       // Get the header element by index and read the value
-      assert.equal(response.headers.get(0).content, 'application/json');
+      assert.equal(response.headers.get(0).toValue(), 'application/json');
 
       // Convenience to get a header by name
       assert.equal(response.header('content-type'), 'application/json');

--- a/test/unit/adapters/swagger20-test.es6
+++ b/test/unit/adapters/swagger20-test.es6
@@ -32,7 +32,7 @@ describe('Swagger Adapter', () => {
     });
 
     it('correctly parses the document', () => {
-      assert.deepEqual(parsedDocument, apiDescriptionExample)
+      assert.deepEqual(parsedDocument, apiDescriptionExample);
     });
   });
 });


### PR DESCRIPTION
This change depends on refractproject/minim#55 and refractproject/minim#66. It
updates Fury to use the latest and greatest interface to refract elements,
including updating the refract API namespace elements, the API Blueprint
serializer, and the Swagger parser.

cc @zdne @kylef @pksunkara @smizell 
