### PR TITLE
Fixed bug with url of an advanced action in legacy AST

### DIFF
--- a/src/legacy/api-blueprint-adapter.coffee
+++ b/src/legacy/api-blueprint-adapter.coffee
@@ -187,7 +187,7 @@ legacyResourcesFrom1AResource = (legacyUrlConverterFn, resource) ->
     # Combine resource & action section, preferring action
     legacyResource = new blueprintAPI.Resource responses: [], requests: []
 
-    legacyResource.url         = legacyUrlConverterFn resource.uriTemplate
+    legacyResource.url         = legacyUrlConverterFn action.attributes?.uriTemplate or resource.uriTemplate
     legacyResource.uriTemplate = resource.uriTemplate
 
     legacyResource.method = action.method

--- a/test/unit/legacy/blueprint-attributes-test.js
+++ b/test/unit/legacy/blueprint-attributes-test.js
@@ -221,4 +221,8 @@ describe('Expose relation and urlTemplate for action', function() {
     assert.equal(postAction.actionUriTemplate, '');
   });
 
+  it ('is equal to url when advanced action', function () {
+    assert.equal(getAction.url, getAction.actionUriTemplate);
+  });
+
 });


### PR DESCRIPTION
Apparently causing apiaryio/api-blueprint#229

/cc @XVincentX 
