### PR TITLE
Implement parse result refract namespace

### DIFF
--- a/src/fury-emitter.js
+++ b/src/fury-emitter.js
@@ -3,7 +3,7 @@ var events = require('events');
 // Default logging function
 function log(message) {
   /*eslint no-unused-vars: 0 */
-  //console.log(message);
+  // console.log(message);
 }
 
 // Default Fury EventEmitter

--- a/src/fury.es6
+++ b/src/fury.es6
@@ -7,8 +7,8 @@ import legacyAPI from './legacy/blueprint';
 import legacyBlueprintParser from './legacy/blueprint-parser';
 import legacyMarkdownRenderer from './legacy/markdown';
 
-// Register API primitives
-import './refract/api';
+// Register Parse Result and API description primitives
+import './refract/parseResult';
 
 /*
  * Find an adapter by a given media type. If no adapter is found, then

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -1,5 +1,6 @@
 /*
- * API-specific refract elements. General structure:
+ * API description-specific refract elements.
+ * General structure:
  *
  * + Category - API, resource group
  *   + Category
@@ -15,7 +16,6 @@
  *           + Asset
  *           + Message body
  *           + Message body schema
- *     + Data structure
  *   + Data structure
  */
 
@@ -329,7 +329,7 @@ export class Category extends ArrayElement {
   }
 }
 
-// Register the API and Resource element Elements.
+// Register the API description element Elements.
 registry
   .register('category', Category)
   .register('copy', Copy)

--- a/src/refract/parseResult.es6
+++ b/src/refract/parseResult.es6
@@ -1,0 +1,48 @@
+/*
+ * Parse result-specific refract elements. Includes the API namespace.
+ * General structure:
+ *
+ * + ParseResult
+ *   + Annotation
+ */
+
+import {
+  ArrayElement, StringElement, registry
+} from 'minim';
+
+import './api';
+
+export class ParseResult extends ArrayElement {
+  constructor(...args) {
+    super(...args);
+    this.element = 'parseResult';
+  }
+
+  get api() {
+    return this.findByClass('api').first();
+  }
+
+  get annotations() {
+    return this.findByElement('annotation');
+  }
+}
+
+export class Annotation extends StringElement {
+  constructor(...args) {
+    super(...args);
+    this.element = 'annotation';
+  }
+
+  get code() {
+    return this.attributes.getValue('code');
+  }
+
+  set code(value) {
+    this.attributes.set('code', value);
+  }
+}
+
+// Register the Parse Result element Elements.
+registry
+  .register('parseResult', ParseResult)
+  .register('annotation', Annotation);


### PR DESCRIPTION
This change implements the [parse result](https://github.com/refractproject/refract-spec/blob/master/namespaces/parse-result.md) namespace and updates existing tests to use it.
