### PR TITLE
Use protagonist to parse into refract elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "dependencies": {
     "apiary-blueprint-parser": "",
     "babel-runtime": "^5.5.6",
-    "drafter": "^0.2.5",
     "json-schema-deref-sync": "^0.1.1",
     "minim": "^0.9.0",
+    "protagonist": "^0.20.1",
     "robotskirt": "",
     "sanitizer": "",
     "swig": "^1.4.2",

--- a/src/adapters/api-blueprint.es6
+++ b/src/adapters/api-blueprint.es6
@@ -1,6 +1,6 @@
-import Drafter from 'drafter';
 import mson from './mson';
 import path from 'path';
+import protagonist from 'protagonist';
 import swig from 'swig';
 
 // Auto-detect via the API Blueprint format metadata.
@@ -100,13 +100,12 @@ export function detect(source) {
  * Parse an API Blueprint into refract elements.
  */
 export function parse({source, generateSourceMap}, done) {
-  const drafter = new Drafter({
-    exportSourcemap: generateSourceMap
-  });
+  const options = {
+    exportSourcemap: generateSourceMap,
+    type: 'refract'
+  };
 
-  drafter.make(source, (err, result) => {
-    // TODO: Figure out what exactly drafter is returning and how
-    //       to request refract output.
+  protagonist.parse(source, options, (err, result) => {
     done(err, result);
   });
 }

--- a/src/fury-emitter.js
+++ b/src/fury-emitter.js
@@ -3,7 +3,7 @@ var events = require('events');
 // Default logging function
 function log(message) {
   /*eslint no-unused-vars: 0 */
-  //console.log(message);
+  // console.log(message);
 }
 
 // Default Fury EventEmitter

--- a/src/legacy/blueprint-parser.coffee
+++ b/src/legacy/blueprint-parser.coffee
@@ -2,7 +2,7 @@
 # Legacy Blueprint parsing interface
 #
 apiaryBlueprintParser = require 'apiary-blueprint-parser'
-Drafter = require 'drafter'
+protagonist = require 'protagonist'
 
 DefaultFuryEmitter = require '../fury-emitter'
 apiBlueprintAdapter = require './api-blueprint-adapter'
@@ -12,6 +12,7 @@ NEW_VERSION_REGEXP = new RegExp '^[\uFEFF]?(((VERSION:( |\t)2)|(FORMAT:( |\t)(X-
 
 STRICT_OPTIONS =
   requireBlueprintName: true
+  type: 'ast'
 
 # Default async parser timeout
 process.env.PARSER_TIMEOUT ?= 10000
@@ -74,8 +75,7 @@ getLocalAst = ({code, blueprintId, sourcemap, emitter}, cb) ->
     # Parsing metric
     t = process.hrtime()
 
-    drafter = new Drafter options
-    drafter.make code, (err, result) ->
+    protagonist.parse code, options, (err, result) ->
       # Parsing metric
       execTime = process.hrtime t
       execTime = execTime[0] + execTime[1]*10e-9 # ns to s


### PR DESCRIPTION
This change removes Drafter.js in favor of Protagonist and uses the new `type`
option to get refract elements out of it. Once C++ Drafter and Protagonist
are completely updated/released, then Fury should be able to parse API
Blueprint and return Minim element instances.

This should be combined with #41 to properly handle the output of Protagonist.
