### PR TITLE
Implement Refract RFC 0002

### DIFF
--- a/src/adapters/swagger20.es6
+++ b/src/adapters/swagger20.es6
@@ -187,11 +187,11 @@ export function parse({ source }, done) {
 
       // For each uriParameter, create an hrefVariable
       if (uriParameters.length > 0) {
-        transition.parameters = new HrefVariables();
+        transition.hrefVariables = new HrefVariables();
 
         uriParameters
           .map(convertParameterToElement)
-          .forEach((member) => transition.parameters.content.push(member));
+          .forEach((member) => transition.hrefVariables.content.push(member));
       }
 
       // Currently, default responses are not supported in API Description format

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -16,6 +16,7 @@
  *           + Asset
  *           + Message body
  *           + Message body schema
+ *   + Transition
  *   + Data structure
  */
 
@@ -194,7 +195,7 @@ export class Transition extends ArrayElement {
     super(...args);
 
     this.element = 'transition';
-    this._attributeElementKeys = ['parameters', 'attributes'];
+    this._attributeElementKeys = ['hrefVariables', 'attributes'];
   }
 
   get method() {
@@ -225,21 +226,28 @@ export class Transition extends ArrayElement {
     }
   }
 
-  get parameters() {
-    return this.attributes.get('parameters');
+  get hrefVariables() {
+    return this.attributes.get('hrefVariables');
   }
 
-  set parameters(value) {
-    this.attributes.set('parameters', value);
+  set hrefVariables(value) {
+    this.attributes.set('hrefVariables', value);
   }
 
-  // The key `attributes` is already taken, so `attr` is used instead.
-  get attr() {
-    return this.attributes.get('attributes');
+  get data() {
+    return this.attributes.get('data');
   }
 
-  set attr(value) {
-    this.attributes.set('attributes', value);
+  set data(value) {
+    this.attributes.set('data', value);
+  }
+
+  get contentTypes() {
+    return this.attributes.get('contentTypes');
+  }
+
+  set contentTypes(value) {
+    this.attributes.set('contentTypes', value);
   }
 
   get transactions() {
@@ -322,6 +330,10 @@ export class Category extends ArrayElement {
 
   get resources() {
     return this.findByElement('resource');
+  }
+
+  get transitions() {
+    return this.findByElement('transition');
   }
 
   get copy() {

--- a/test/fixtures/adapters/swagger20/api-description-example.json
+++ b/test/fixtures/adapters/swagger20/api-description-example.json
@@ -306,7 +306,7 @@
             "title": "findPetsByStatus"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -419,7 +419,7 @@
             "title": "findPetsByTags"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -557,7 +557,7 @@
             "title": "updatePetWithForm"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -646,7 +646,7 @@
             "title": "getPetById"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -773,7 +773,7 @@
             "title": "deletePet"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -862,7 +862,7 @@
             "title": "partialUpdate"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -1159,7 +1159,7 @@
             "title": "updateUser"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -1310,7 +1310,7 @@
             "title": "deleteUser"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -1422,7 +1422,7 @@
             "title": "getUserByName"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -1558,7 +1558,7 @@
             "title": "loginUser"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -1890,7 +1890,7 @@
             "title": "deleteOrder"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},
@@ -2002,7 +2002,7 @@
             "title": "getOrderById"
           },
           "attributes": {
-            "parameters": {
+            "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
               "attributes": {},


### PR DESCRIPTION
This implements the changes required for [Refract RFC 0002](https://github.com/refractproject/rfcs/blob/master/text/0002-clarity-api-description.md).

RFC 0003 depends on refractproject/minim#72.
RFC 0004 isn't yet merged refractproject/refract-spec#41.
These two will be done in a separate pull request.
