### PR TITLE
Implement Refract RFCs 3 & 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-runtime": "^5.5.6",
     "drafter": "^0.2.5",
     "json-schema-deref-sync": "^0.1.1",
-    "minim": "^0.9.0",
+    "minim": "^0.10.0",
     "robotskirt": "",
     "sanitizer": "",
     "swig": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "compile": "eslint --ext .js,.es6 src && babel src --optional runtime --out-dir lib && coffee -b -c -o lib/ src/",
     "precoverage": "npm run compile",
-    "coverage": "istanbul cover _mocha -- --compilers es6:babel/register,coffee:coffee-script/register -R spec --recursive",
+    "coverage": "istanbul cover _mocha -- --compilers es6:babel/register,coffee:coffee-script/register -R dot --recursive",
     "precoveralls": "npm run coverage",
     "coveralls": "coveralls <coverage/lcov.info",
     "pretest": "npm run compile",

--- a/src/adapters/api-blueprint.es6
+++ b/src/adapters/api-blueprint.es6
@@ -77,11 +77,20 @@ function pretty(input) {
   return prettified;
 }
 
+/*
+ * Return all child elements with the element type of `copy` in a plain
+ * old js array.
+ */
+function getCopy(element) {
+  return element.children((item) => item.element === 'copy').content;
+}
+
 swig.setFilter('mson', mson);
 swig.setFilter('indent', indent);
 swig.setFilter('bodyOnly', bodyOnly);
 swig.setFilter('resourceShorthand', resourceShorthand);
 swig.setFilter('pretty', pretty);
+swig.setFilter('getCopy', getCopy);
 
 export const name = 'api-blueprint';
 export const mediaTypes = [

--- a/src/adapters/swagger20.es6
+++ b/src/adapters/swagger20.es6
@@ -8,6 +8,7 @@ import {
 import '../refract/api';
 
 // Define API Description elements
+const Copy = registry.getElementClass('copy');
 const Category = registry.getElementClass('category');
 const Resource = registry.getElementClass('resource');
 const Transition = registry.getElementClass('transition');
@@ -114,7 +115,9 @@ export function parse({ source }, done) {
   // Root API Element
   api.classes.push('api');
   api.meta.set('title', source.info.title);
-  api.meta.set('description', source.info.description);
+  if (source.info.description) {
+    api.content.push(new Copy(source.info.description));
+  }
 
   // Swagger has a paths object to loop through
   // The key is the href
@@ -177,10 +180,10 @@ export function parse({ source }, done) {
 
       // Prefer description over summary since description is more complete.
       // According to spec, summary SHOULD only be 120 characters
-      if (methodValue.description) {
-        transition.meta.set('description', methodValue.description);
-      } else if (methodValue.summary) {
-        transition.meta.set('description', methodValue.summary);
+      let transitionDescription = methodValue.description ?
+        methodValue.description : methodValue.summary;
+      if (transitionDescription) {
+        transition.push(new Copy(transitionDescription));
       }
 
       transition.meta.set('title', methodValue.operationId);

--- a/src/adapters/swagger20.es6
+++ b/src/adapters/swagger20.es6
@@ -79,7 +79,7 @@ function derefJsonSchema(jsonSchemaWithRefs) {
 function createAssetFromJsonSchema(jsonSchemaWithRefs) {
   let jsonSchema = derefJsonSchema(jsonSchemaWithRefs);
   let schemaAsset = new Asset(JSON.stringify(jsonSchema));
-  schemaAsset.class.push('messageBodySchema');
+  schemaAsset.classes.push('messageBodySchema');
   schemaAsset.attributes.set('contentType', 'application/schema+json');
 
   return schemaAsset;
@@ -112,7 +112,7 @@ export function parse({ source }, done) {
   let api = new Category();
 
   // Root API Element
-  api.class.push('api');
+  api.classes.push('api');
   api.meta.set('title', source.info.title);
   api.meta.set('description', source.info.description);
 

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -182,11 +182,11 @@ export class HttpTransaction extends ArrayElement {
   }
 
   get request() {
-    return this.findByElement('httpRequest').first();
+    return this.children((item) => item.element === 'httpRequest').first();
   }
 
   get response() {
-    return this.findByElement('httpResponse').first();
+    return this.children((item) => item.element === 'httpResponse').first();
   }
 }
 
@@ -251,7 +251,7 @@ export class Transition extends ArrayElement {
   }
 
   get transactions() {
-    return this.findByElement('httpTransaction');
+    return this.children((item) => item.element === 'httpTransaction');
   }
 }
 
@@ -280,11 +280,11 @@ export class Resource extends ArrayElement {
   }
 
   get transitions() {
-    return this.findByElement('transition');
+    return this.children((item) => item.element === 'transition');
   }
 
   get dataStructure() {
-    return this.findByElement('dataStructure').first();
+    return this.children((item) => item.element === 'dataStructure').first();
   }
 }
 
@@ -344,27 +344,27 @@ export class Category extends ArrayElement {
   }
 
   get resourceGroups() {
-    return this.findByClass('resourceGroup');
+    return this.children((item) => item.classes.contains('resourceGroup'));
   }
 
   get dataStructures() {
-    return this.findByClass('dataStructures');
+    return this.children((item) => item.classes.contains('dataStructures'));
   }
 
   get scenarios() {
-    return this.findByClass('scenario');
+    return this.children((item) => item.classes.contains('scenario'));
   }
 
   get resources() {
-    return this.findByElement('resource');
+    return this.children((item) => item.element === 'resource');
   }
 
   get transitions() {
-    return this.findByElement('transition');
+    return this.children((item) => item.element === 'transition');
   }
 
   get copy() {
-    return this.findByElement('copy');
+    return this.children((item) => item.element === 'copy');
   }
 }
 

--- a/src/refract/api.es6
+++ b/src/refract/api.es6
@@ -124,7 +124,7 @@ class HttpMessagePayload extends ArrayElement {
     // Returns the *first* message body. Only one should be defined according
     // to the spec, but it's possible to include more.
     return this.filter((item) => {
-      return item.element === 'asset' && item.class.contains('messageBody');
+      return item.element === 'asset' && item.classes.contains('messageBody');
     }).first();
   }
 
@@ -132,7 +132,7 @@ class HttpMessagePayload extends ArrayElement {
     // Returns the *first* message body schema. Only one should be defined
     // according to the spec, but it's possible to include more.
     return this.filter((item) => {
-      return item.element === 'asset' && item.class.contains('messageBodySchema');
+      return item.element === 'asset' && item.classes.contains('messageBodySchema');
     }).first();
   }
 }
@@ -288,10 +288,37 @@ export class Resource extends ArrayElement {
   }
 }
 
-export class DataStructure extends ObjectElement {
+export class DataStructure extends BaseElement {
   constructor(...args) {
     super(...args);
     this.element = 'dataStructure';
+    if (this.content !== undefined) {
+      this.content = registry.toElement(this.content);
+    }
+  }
+
+  toRefract() {
+    const refract = super.toRefract();
+    refract.content = registry.toRefract(refract.content);
+    return refract;
+  }
+
+  toCompactRefract() {
+    const compactRefract = super.toCompactRefract();
+    compactRefract.content = registry.toCompactRefract(compactRefract.content);
+    return compactRefract;
+  }
+
+  fromRefract(doc) {
+    super.fromRefract(doc);
+    this.content = registry.fromRefract(doc.content);
+    return this;
+  }
+
+  fromCompactRefract(tuple) {
+    super.fromCompactRefract(tuple);
+    this.content = registry.fromCompactRefract(tuple[3]);
+    return this;
   }
 }
 

--- a/src/refract/parseResult.es6
+++ b/src/refract/parseResult.es6
@@ -19,11 +19,11 @@ export class ParseResult extends ArrayElement {
   }
 
   get api() {
-    return this.findByClass('api').first();
+    return this.children((item) => item.classes.contains('api')).first();
   }
 
   get annotations() {
-    return this.findByElement('annotation');
+    return this.children((item) => item.element === 'annotation');
   }
 }
 

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -166,7 +166,7 @@ FORMAT: 1A
     {% if item.element === 'category' && item.classes.contains('resourceGroup') %}
       {{ renderGroup(item) }}
     {% endif %}
-    {% if item.element === 'category' && item.classes.contains('dataStructure') %}
+    {% if item.element === 'category' && item.classes.contains('dataStructures') %}
       {{ renderDataStructures(item) }}
     {% endif %}
     {% if item.element === 'resource' %}

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -17,7 +17,7 @@ FORMAT: 1A
 
   {% endif %}
   {% if example.dataStructure %}
-    {{ example.dataStructure|mson|indent(4) }}
+    {{ example.dataStructure.content|mson|indent(4) }}
   {% endif %}
   {% if example.messageBody %}
     + Body
@@ -113,7 +113,7 @@ FORMAT: 1A
 {{ renderParameters(resource.hrefVariables) }}
 {% endif %}
 {% if resource.dataStructure %}
-{{ resource.dataStructure|mson }}
+{{ resource.dataStructure.content|mson }}
 {% endif %}
 {% for transition in resource.transitions.content %}
   {{ renderTransition(transition, href) }}
@@ -140,7 +140,7 @@ FORMAT: 1A
 ## Data Structures
 
 {% for dataStructure in dataStructures.content %}
-{{ dataStructure|mson }}
+{{ dataStructure.content|mson }}
 {% endfor %}
 {% endmacro %}
 
@@ -155,10 +155,10 @@ FORMAT: 1A
     {% if item.element === 'copy' %}
 {{ item.content }}
     {% endif %}
-    {% if item.element === 'category' && item.class.contains('resourceGroup') %}
+    {% if item.element === 'category' && item.classes.contains('resourceGroup') %}
       {{ renderGroup(item) }}
     {% endif %}
-    {% if item.element === 'category' && item.class.contains('dataStructure') %}
+    {% if item.element === 'category' && item.classes.contains('dataStructure') %}
       {{ renderDataStructures(item) }}
     {% endif %}
     {% if item.element === 'resource' %}

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -79,6 +79,10 @@ FORMAT: 1A
 
 {{ transition.description }}
 
+{% for copy in transition|getCopy %}
+{{ copy.content }}
+{% endfor %}
+
 {% if transition.parameters.length %}
   {{ renderParameters(transition.parameters) }}
 {% endif %}
@@ -102,6 +106,10 @@ FORMAT: 1A
 ### {{ resource.title|default('Resource') }} [{{ resource.href }}]
 
 {{ resource.description }}
+
+{% for copy in resource|getCopy %}
+{{ copy.content }}
+{% endfor %}
 {% else %}
   {#
     We are using the shorthand, make sure to pass any href down to the

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -9,11 +9,11 @@ FORMAT: 1A
 {% if example|bodyOnly %}
         {{ example.messageBody.content|indent(8) }}
 {% else %}
-  {% if example.headers.exclude('Content-Type').length %}
+  {% if example.headers && example.headers.exclude('Content-Type').length %}
     + Headers
 
       {% for header in example.headers.exclude('Content-Type').content %}
-            {{ header.name }}: {{ header.content }}{% endfor %}
+            {{ header.key.toValue() }}: {{ header.value.toValue() }}{% endfor %}
 
   {% endif %}
   {% if example.dataStructure %}

--- a/templates/api-blueprint.swig
+++ b/templates/api-blueprint.swig
@@ -6,6 +6,10 @@ FORMAT: 1A
 
 
 {% macro renderExample(example) %}
+{% for copy in example|getCopy %}
+{{ copy.content }}
+{% endfor %}
+
 {% if example|bodyOnly %}
         {{ example.messageBody.content|indent(8) }}
 {% else %}
@@ -77,8 +81,6 @@ FORMAT: 1A
 #### {{ transition.method }}{% if href %} {{ href }}{% elseif transition.computedHref %} {{ transition.computedHref }}{% endif %}
 {% endif %}
 
-{{ transition.description }}
-
 {% for copy in transition|getCopy %}
 {{ copy.content }}
 {% endfor %}
@@ -104,8 +106,6 @@ FORMAT: 1A
 {% if !resource|resourceShorthand %}
 {% set href = null %}
 ### {{ resource.title|default('Resource') }} [{{ resource.href }}]
-
-{{ resource.description }}
 
 {% for copy in resource|getCopy %}
 {{ copy.content }}
@@ -134,8 +134,6 @@ FORMAT: 1A
 
 {% macro renderGroup(group) %}
 ## Group {{ group.title }}
-
-{{ group.description }}
 
 {{ renderCategory(group) }}
 {% endmacro %}

--- a/test/fixtures/adapters/swagger20/api-description-example.json
+++ b/test/fixtures/adapters/swagger20/api-description-example.json
@@ -1,7 +1,7 @@
 {
   "element": "category",
   "meta": {
-    "class": [
+    "classes": [
       "api"
     ],
     "title": "Swagger Sample App",
@@ -125,7 +125,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -161,7 +161,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -197,7 +197,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -233,7 +233,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -363,7 +363,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -501,7 +501,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -705,7 +705,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -911,7 +911,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -932,7 +932,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -960,7 +960,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1061,7 +1061,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1118,7 +1118,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1208,7 +1208,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1244,7 +1244,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1280,7 +1280,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1479,7 +1479,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1640,7 +1640,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1756,7 +1756,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1813,7 +1813,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -1849,7 +1849,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },
@@ -2059,7 +2059,7 @@
                     {
                       "element": "asset",
                       "meta": {
-                        "class": [
+                        "classes": [
                           "messageBodySchema"
                         ]
                       },

--- a/test/fixtures/adapters/swagger20/api-description-example.json
+++ b/test/fixtures/adapters/swagger20/api-description-example.json
@@ -4,11 +4,16 @@
     "classes": [
       "api"
     ],
-    "title": "Swagger Sample App",
-    "description": "This is a sample server Petstore server.  You can find out more about Swagger \n    at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.  For this sample,\n    you can use the api key \"special-key\" to test the authorization filters"
+    "title": "Swagger Sample App"
   },
   "attributes": {},
   "content": [
+    {
+      "element": "copy",
+      "meta": {},
+      "attributes": {},
+      "content": "This is a sample server Petstore server.  You can find out more about Swagger \n    at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.  For this sample,\n    you can use the api key \"special-key\" to test the authorization filters"
+    },
     {
       "element": "resource",
       "meta": {
@@ -21,11 +26,16 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Empty responses",
             "title": "emptyResponses"
           },
           "attributes": {},
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Empty responses"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -63,11 +73,16 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Only default response set",
             "title": "onlyDefaultResponse"
           },
           "attributes": {},
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Only default response set"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -105,11 +120,16 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Update an existing pet",
             "title": "updatePet"
           },
           "attributes": {},
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Update an existing pet"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -302,7 +322,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Finds Pets by status",
             "title": "findPetsByStatus"
           },
           "attributes": {
@@ -340,6 +359,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Finds Pets by status"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -415,7 +440,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Finds Pets by tags",
             "title": "findPetsByTags"
           },
           "attributes": {
@@ -478,6 +502,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Finds Pets by tags"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -553,7 +583,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Updates a pet in the store with form data",
             "title": "updatePetWithForm"
           },
           "attributes": {
@@ -591,6 +620,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Updates a pet in the store with form data"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -642,7 +677,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Find pet by ID",
             "title": "getPetById"
           },
           "attributes": {
@@ -682,6 +716,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Find pet by ID"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -769,7 +809,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Deletes a pet",
             "title": "deletePet"
           },
           "attributes": {
@@ -807,6 +846,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Deletes a pet"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -858,7 +903,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "partial updates to a pet",
             "title": "partialUpdate"
           },
           "attributes": {
@@ -896,6 +940,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "partial updates to a pet"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -997,11 +1047,16 @@
         {
           "element": "transition",
           "meta": {
-            "description": "uploads an image",
             "title": "uploadFile"
           },
           "attributes": {},
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "uploads an image"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -1041,11 +1096,16 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Creates list of users with given input array",
             "title": "createUsersWithArrayInput"
           },
           "attributes": {},
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Creates list of users with given input array"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -1098,11 +1158,16 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Creates list of users with given list input",
             "title": "createUsersWithListInput"
           },
           "attributes": {},
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Creates list of users with given list input"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -1155,7 +1220,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Updated user",
             "title": "updateUser"
           },
           "attributes": {
@@ -1194,6 +1258,12 @@
           },
           "content": [
             {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Updated user"
+            },
+            {
               "element": "httpTransaction",
               "meta": {},
               "attributes": {},
@@ -1306,7 +1376,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Delete user",
             "title": "deleteUser"
           },
           "attributes": {
@@ -1345,6 +1414,12 @@
           },
           "content": [
             {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Delete user"
+            },
+            {
               "element": "httpTransaction",
               "meta": {},
               "attributes": {},
@@ -1418,7 +1493,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Get user by user name",
             "title": "getUserByName"
           },
           "attributes": {
@@ -1456,6 +1530,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Get user by user name"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -1554,7 +1634,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Logs user into the system",
             "title": "loginUser"
           },
           "attributes": {
@@ -1617,6 +1696,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Logs user into the system"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -1692,11 +1777,16 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Logs out current logged in user session",
             "title": "logoutUser"
           },
           "attributes": {},
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Logs out current logged in user session"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -1736,11 +1826,16 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Create user",
             "title": "createUser"
           },
           "attributes": {},
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Create user"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -1793,11 +1888,16 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Place an order for a pet",
             "title": "placeOrder"
           },
           "attributes": {},
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Place an order for a pet"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -1886,7 +1986,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Delete purchase order by ID",
             "title": "deleteOrder"
           },
           "attributes": {
@@ -1924,6 +2023,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Delete purchase order by ID"
+            },
             {
               "element": "httpTransaction",
               "meta": {},
@@ -1998,7 +2103,6 @@
         {
           "element": "transition",
           "meta": {
-            "description": "Find purchase order by ID",
             "title": "getOrderById"
           },
           "attributes": {
@@ -2036,6 +2140,12 @@
             }
           },
           "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "Find purchase order by ID"
+            },
             {
               "element": "httpTransaction",
               "meta": {},

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -32,8 +32,9 @@ const refractedApi = [
           ]]],
           ['transition', {}, {}, [
             ['httpTransaction', {title: 'Get a frob'}, {}, [
-              ['copy', {}, {}, 'Gets information about a single frob instance'],
-              ['httpRequest', {}, {method: 'GET'}, []],
+              ['httpRequest', {}, {method: 'GET'}, [
+                ['copy', {}, {}, 'Gets information about a single frob instance']
+              ]],
               ['httpResponse', {}, {statusCode: 200, headers: ['httpHeaders', {}, {}, [
                 ['member', {}, {}, {
                   key: ['string', {}, {}, 'Content-Type'],

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -6,8 +6,8 @@ import minim from 'minim';
 
 const refractedApi = [
   'parseResult', {}, {}, [
-    ['category', {'class': ['api'], title: 'My API', description: 'An API description.'}, {}, [
-      ['category', {'class': ['resourceGroup'], title: 'My Group', description: 'This is a group of resources'}, {}, [
+    ['category', {'classes': ['api'], title: 'My API', description: 'An API description.'}, {}, [
+      ['category', {'classes': ['resourceGroup'], title: 'My Group', description: 'This is a group of resources'}, {}, [
         ['copy', {}, {contentType: 'text/plain'}, 'Extra text'],
         ['resource', {title: 'Frob', description: 'A frob does something.'}, {
           href: '/frobs/{id}',
@@ -18,7 +18,7 @@ const refractedApi = [
             }]
           ]]
           }, [
-          ['dataStructure', {}, {}, [
+          ['dataStructure', {}, {}, ['object', {}, {}, [
             ['member', {}, {'typeAttributes': ['required']}, {
               'key': ['string', {}, {}, 'id'],
               'value': ['string', {}, {}, null]
@@ -27,14 +27,14 @@ const refractedApi = [
               'key': ['string', {}, {}, 'tag'],
               'value': ['string', {}, {}, null]
             }]
-          ]],
+          ]]],
           ['transition', {}, {}, [
             ['httpTransaction', {title: 'Get a frob', description: 'Gets information about a single frob instance'}, {}, [
               ['httpRequest', {}, {method: 'GET'}, null],
               ['httpResponse', {}, {statusCode: 200, headers: ['httpHeaders', {}, {}, [
                 ['string', {name: 'Content-Type'}, {}, 'application/json']
               ]]}, [
-                ['asset', {'class': ['messageBody']}, {}, '{\n  "id": "1",\n  "tag": "foo"\n}\n']
+                ['asset', {'classes': ['messageBody']}, {}, '{\n  "id": "1",\n  "tag": "foo"\n}\n']
               ]]
             ]]
           ]]
@@ -42,7 +42,7 @@ const refractedApi = [
       ]]
     ]
   ],
-  ['annotation', {'class': ['warning']}, {'code': 6, 'sourceMap': [[0, 10]]}, 'description']
+  ['annotation', {'classes': ['warning']}, {'code': 6, 'sourceMap': [[0, 10]]}, 'description']
 ]];
 
 describe('Nodes.js require', () => {
@@ -141,7 +141,7 @@ describe('Parser', () => {
 describe('Refract loader', () => {
   describe('autodetect', () => {
     it('should support shorthand', () => {
-      let api = fury.load(['category', {'class': 'api'}, {}, []]);
+      let api = fury.load(['category', {'classes': 'api'}, {}, []]);
       assert(api);
     });
 
@@ -149,7 +149,7 @@ describe('Refract loader', () => {
       let api = fury.load({
         element: 'category',
         meta: {
-          'class': 'api'
+          'classes': 'api'
         },
         content: []
       });

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -31,10 +31,9 @@ const refractedApi = [
             }]
           ]]],
           ['transition', {}, {}, [
+            ['copy', {}, {}, 'Gets information about a single frob instance'],
             ['httpTransaction', {title: 'Get a frob'}, {}, [
-              ['httpRequest', {}, {method: 'GET'}, [
-                ['copy', {}, {}, 'Gets information about a single frob instance']
-              ]],
+              ['httpRequest', {}, {method: 'GET'}, []],
               ['httpResponse', {}, {statusCode: 200, headers: ['httpHeaders', {}, {}, [
                 ['member', {}, {}, {
                   key: ['string', {}, {}, 'Content-Type'],

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -6,10 +6,11 @@ import minim from 'minim';
 
 const refractedApi = [
   'parseResult', {}, {}, [
-    ['category', {'classes': ['api'], title: 'My API', description: 'An API description.'}, {}, [
-      ['category', {'classes': ['resourceGroup'], title: 'My Group', description: 'This is a group of resources'}, {}, [
-        ['copy', {}, {contentType: 'text/plain'}, 'Extra text'],
-        ['resource', {title: 'Frob', description: 'A frob does something.'}, {
+    ['category', {'classes': ['api'], title: 'My API'}, {}, [
+      ['copy', {}, {}, 'An API description.'],
+      ['category', {'classes': ['resourceGroup'], title: 'My Group'}, {}, [
+        ['copy', {}, {contentType: 'text/plain'}, 'This is a group of resources'],
+        ['resource', {title: 'Frob'}, {
           href: '/frobs/{id}',
           hrefVariables: ['hrefVariables', {}, {}, [
             ['member', {}, {}, {
@@ -18,6 +19,7 @@ const refractedApi = [
             }]
           ]]
           }, [
+          ['copy', {}, {}, 'A frob does something.'],
           ['dataStructure', {}, {}, ['object', {}, {}, [
             ['member', {}, {'typeAttributes': ['required']}, {
               'key': ['string', {}, {}, 'id'],
@@ -29,7 +31,8 @@ const refractedApi = [
             }]
           ]]],
           ['transition', {}, {}, [
-            ['httpTransaction', {title: 'Get a frob', description: 'Gets information about a single frob instance'}, {}, [
+            ['httpTransaction', {title: 'Get a frob'}, {}, [
+              ['copy', {}, {}, 'Gets information about a single frob instance'],
               ['httpRequest', {}, {method: 'GET'}, null],
               ['httpResponse', {}, {statusCode: 200, headers: ['httpHeaders', {}, {}, [
                 ['string', {name: 'Content-Type'}, {}, 'application/json']
@@ -200,7 +203,8 @@ describe('Refract loader', () => {
 
     it('should contain a single copy element', () => {
       assert.equal(api.resourceGroups.get(0).copy.length, 1);
-      assert.equal(api.resourceGroups.get(0).copy.get(0).content, 'Extra text');
+      assert.equal(api.resourceGroups.get(0).copy.get(0).content,
+                   'This is a group of resources');
     });
 
     it('should contain a single resource', () => {

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -33,7 +33,7 @@ const refractedApi = [
           ['transition', {}, {}, [
             ['httpTransaction', {title: 'Get a frob'}, {}, [
               ['copy', {}, {}, 'Gets information about a single frob instance'],
-              ['httpRequest', {}, {method: 'GET'}, null],
+              ['httpRequest', {}, {method: 'GET'}, []],
               ['httpResponse', {}, {statusCode: 200, headers: ['httpHeaders', {}, {}, [
                 ['member', {}, {}, {
                   key: ['string', {}, {}, 'Content-Type'],

--- a/test/integration/fury-test.es6
+++ b/test/integration/fury-test.es6
@@ -35,7 +35,10 @@ const refractedApi = [
               ['copy', {}, {}, 'Gets information about a single frob instance'],
               ['httpRequest', {}, {method: 'GET'}, null],
               ['httpResponse', {}, {statusCode: 200, headers: ['httpHeaders', {}, {}, [
-                ['string', {name: 'Content-Type'}, {}, 'application/json']
+                ['member', {}, {}, {
+                  key: ['string', {}, {}, 'Content-Type'],
+                  value: ['string', {}, {}, 'application/json']
+                }]
               ]]}, [
                 ['asset', {'classes': ['messageBody']}, {}, '{\n  "id": "1",\n  "tag": "foo"\n}\n']
               ]]
@@ -246,7 +249,7 @@ describe('Refract loader', () => {
       const response = resource.transitions.get(0).transactions.get(0).response;
 
       // Get the header element by index and read the value
-      assert.equal(response.headers.get(0).toValue(), 'application/json');
+      assert.equal(response.headers.get(0).value.toValue(), 'application/json');
 
       // Convenience to get a header by name
       assert.equal(response.header('content-type'), 'application/json');

--- a/test/integration/serializers/basic.json
+++ b/test/integration/serializers/basic.json
@@ -5,7 +5,10 @@
         ["httpTransaction", {}, {}, [
           ["httpRequest", {}, {"method": "GET", "href": "/message"}, null],
           ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
-            ["string", {"name": "Content-Type"}, {}, "text/plain"]
+            ["member", {}, {}, {
+              "key": ["string", {}, {}, "Content-Type"],
+              "value": ["string", {}, {}, "text/plain"]
+            }]
           ]]}, [
             ["asset", {"classes": ["messageBody"]}, {}, "Hello, World!"]
           ]]

--- a/test/integration/serializers/basic.json
+++ b/test/integration/serializers/basic.json
@@ -7,7 +7,7 @@
           ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
             ["string", {"name": "Content-Type"}, {}, "text/plain"]
           ]]}, [
-            ["asset", {"class": ["messageBody"]}, {}, "Hello, World!"]
+            ["asset", {"classes": ["messageBody"]}, {}, "Hello, World!"]
           ]]
         ]]
       ]]

--- a/test/integration/serializers/basic.json
+++ b/test/integration/serializers/basic.json
@@ -3,7 +3,7 @@
     ["resource", {}, {}, [
       ["transition", {}, {}, [
         ["httpTransaction", {}, {}, [
-          ["httpRequest", {}, {"method": "GET", "href": "/message"}, null],
+          ["httpRequest", {}, {"method": "GET", "href": "/message"}, []],
           ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
             ["member", {}, {}, {
               "key": ["string", {}, {}, "Content-Type"],

--- a/test/integration/serializers/sample.apib
+++ b/test/integration/serializers/sample.apib
@@ -39,6 +39,8 @@ A frob does something.
 
 #### GET
 
+Gets information about a single frob instance
+
 + Relation: Frob
 
 + Response 200 (application/json)

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -1,6 +1,6 @@
 [
-  "category", {"class": ["api"], "title": "My API", "description": "An API description."}, {}, [
-    ["category", {"class": ["resourceGroup"], "title": "My Group", "description": "This is a group of resources"}, {}, [
+  "category", {"classes": ["api"], "title": "My API", "description": "An API description."}, {}, [
+    ["category", {"classes": ["resourceGroup"], "title": "My Group", "description": "This is a group of resources"}, {}, [
       ["copy", {}, {"contentType": "text/plain"}, "Extra text"],
       ["resource", {"title": "Frob", "description": "A frob does something."}, {
         "href": "/frobs/{id}",
@@ -11,7 +11,7 @@
             }]
           ]]
         }, [
-        ["dataStructure", {}, {}, [
+        ["dataStructure", {}, {}, ["object", {}, {}, [
           ["member", {}, {"typeAttributes": ["required"]}, {
             "key": ["string", {}, {}, "id"],
             "value": ["string", {}, {}, null]
@@ -31,7 +31,7 @@
                 ]]
             ]]
           }]
-        ]],
+        ]]],
         ["transition", {}, {"relation": "Frob"}, [
           ["httpTransaction", {"title": "Get a frob", "description": "Gets information about a single frob instance"}, {}, [
             ["httpRequest", {}, {"method": "GET"}, null],
@@ -39,8 +39,8 @@
               ["string", {"name": "Content-Type"}, {}, "application/json"],
               ["string", {"name": "Authorization"}, {}, "Bearer abc123"]
             ]]}, [
-              ["asset", {"class": ["messageBody"]}, {}, "{\n  \"id\": \"1\",\n  \"tags\": [\n    {\n      \"name\": \"foo\",\n      \"count\": 23\n    }\n  ]\n}\n"],
-              ["asset", {"class": ["messageBodySchema"]}, {}, "{\"type\": \"object\",  \"properties\": {\"id\": {\"type\": \"string\"},\"tags\": {      \"type\": \"array\"}}}"]
+              ["asset", {"classes": ["messageBody"]}, {}, "{\n  \"id\": \"1\",\n  \"tags\": [\n    {\n      \"name\": \"foo\",\n      \"count\": 23\n    }\n  ]\n}\n"],
+              ["asset", {"classes": ["messageBodySchema"]}, {}, "{\"type\": \"object\",  \"properties\": {\"id\": {\"type\": \"string\"},\"tags\": {      \"type\": \"array\"}}}"]
             ]]
           ]]
         ]],
@@ -52,13 +52,13 @@
         ]]
       ]]
     ]],
-    ["category", {"class": ["dataStructure"]}, {}, [
-      ["dataStructure", {"title": "User"}, {}, [
+    ["category", {"classes": ["dataStructure"]}, {}, [
+      ["dataStructure", {}, {}, ["object", {"title": "User"}, {}, [
         ["member", {}, {"typeAttributes": ["required"]}, {
           "key": ["string", {}, {}, "name"],
           "value": ["string", {}, {}, null]
         }]
-      ]]
+      ]]]
     ]]
   ]
 ]

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -38,7 +38,7 @@
         ["transition", {}, {"relation": "Frob"}, [
           ["httpTransaction", {"title": "Get a frob"}, {}, [
             ["copy", {}, {}, "Gets information about a single frob instance"],
-            ["httpRequest", {}, {"method": "GET"}, null],
+            ["httpRequest", {}, {"method": "GET"}, []],
             ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
               ["member", {}, {}, {
                 "key": ["string", {}, {}, "Content-Type"],
@@ -63,7 +63,7 @@
         ]]
       ]]
     ]],
-    ["category", {"classes": ["dataStructure"]}, {}, [
+    ["category", {"classes": ["dataStructures"]}, {}, [
       ["dataStructure", {}, {}, ["object", {"title": "User"}, {}, [
         ["member", {}, {"typeAttributes": ["required"]}, {
           "key": ["string", {}, {}, "name"],

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -36,8 +36,8 @@
           }]
         ]]],
         ["transition", {}, {"relation": "Frob"}, [
+          ["copy", {}, {}, "Gets information about a single frob instance"],
           ["httpTransaction", {"title": "Get a frob"}, {}, [
-            ["copy", {}, {}, "Gets information about a single frob instance"],
             ["httpRequest", {}, {"method": "GET"}, []],
             ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
               ["member", {}, {}, {

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -1,8 +1,10 @@
 [
-  "category", {"classes": ["api"], "title": "My API", "description": "An API description."}, {}, [
-    ["category", {"classes": ["resourceGroup"], "title": "My Group", "description": "This is a group of resources"}, {}, [
+  "category", {"classes": ["api"], "title": "My API"}, {}, [
+    ["copy", {}, {}, "An API description."],
+    ["category", {"classes": ["resourceGroup"], "title": "My Group"}, {}, [
+      ["copy", {}, {}, "This is a group of resources"],
       ["copy", {}, {"contentType": "text/plain"}, "Extra text"],
-      ["resource", {"title": "Frob", "description": "A frob does something."}, {
+      ["resource", {"title": "Frob"}, {
         "href": "/frobs/{id}",
         "hrefVariables": ["hrefVariables", {}, {}, [
             ["member", {}, {"typeAttributes": ["required"]}, {
@@ -11,6 +13,7 @@
             }]
           ]]
         }, [
+        ["copy", {}, {}, "A frob does something."],
         ["dataStructure", {}, {}, ["object", {}, {}, [
           ["member", {}, {"typeAttributes": ["required"]}, {
             "key": ["string", {}, {}, "id"],
@@ -33,7 +36,8 @@
           }]
         ]]],
         ["transition", {}, {"relation": "Frob"}, [
-          ["httpTransaction", {"title": "Get a frob", "description": "Gets information about a single frob instance"}, {}, [
+          ["httpTransaction", {"title": "Get a frob"}, {}, [
+            ["copy", {}, {}, "Gets information about a single frob instance"],
             ["httpRequest", {}, {"method": "GET"}, null],
             ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
               ["string", {"name": "Content-Type"}, {}, "application/json"],
@@ -44,7 +48,8 @@
             ]]
           ]]
         ]],
-        ["transition", {"title": "Restart a frob", "description": "Restart a frob instance"}, {"relation": "restart"}, [
+        ["transition", {"title": "Restart a frob"}, {"relation": "restart"}, [
+          ["copy", {}, {}, "Restart a frob instance"],
           ["httpTransaction", {}, {}, [
             ["httpRequest", {}, {"method": "POST"}, []],
             ["httpResponse", {}, {}, []]

--- a/test/integration/serializers/sample.json
+++ b/test/integration/serializers/sample.json
@@ -40,8 +40,14 @@
             ["copy", {}, {}, "Gets information about a single frob instance"],
             ["httpRequest", {}, {"method": "GET"}, null],
             ["httpResponse", {}, {"statusCode": 200, "headers": ["httpHeaders", {}, {}, [
-              ["string", {"name": "Content-Type"}, {}, "application/json"],
-              ["string", {"name": "Authorization"}, {}, "Bearer abc123"]
+              ["member", {}, {}, {
+                "key": ["string", {}, {}, "Content-Type"],
+                "value": ["string", {}, {}, "application/json"]
+              }],
+              ["member", {}, {}, {
+                "key": ["string", {}, {}, "Authorization"],
+                "value": ["string", {}, {}, "Bearer abc123"]
+              }]
             ]]}, [
               ["asset", {"classes": ["messageBody"]}, {}, "{\n  \"id\": \"1\",\n  \"tags\": [\n    {\n      \"name\": \"foo\",\n      \"count\": 23\n    }\n  ]\n}\n"],
               ["asset", {"classes": ["messageBodySchema"]}, {}, "{\"type\": \"object\",  \"properties\": {\"id\": {\"type\": \"string\"},\"tags\": {      \"type\": \"array\"}}}"]

--- a/test/unit/refract/api.es6
+++ b/test/unit/refract/api.es6
@@ -1,0 +1,498 @@
+/*
+ * Tests for API description namespace elements, including all their
+ * convenience properties and methods.
+ */
+
+import chai, {Assertion, expect} from 'chai';
+
+import {BaseElement} from 'minim';
+import {
+  Asset, Category, Copy, DataStructure, HttpMessagePayload, HttpRequest,
+  HttpResponse, HttpTransaction, Resource, Transition
+} from '../../../lib/refract/api';
+
+chai.use((_chai, utils) => {
+  /*
+   * Asserts that an element has a certain class.
+   */
+  utils.addMethod(Assertion.prototype, 'class', function hasClass(name) {
+    const obj = this._obj;
+    this.assert(
+      obj.classes.contains(name),
+      'Expected class list #{act} to contain #{exp}',
+      'Expected class list #{act} to not contain #{exp}',
+      name,
+      obj.classes.toValue()
+    );
+  });
+
+  /*
+   * Modifies the current object to be the value of the given attribute.
+   * Can be chained to assertions, e.g:
+   *
+   *    expect(item).attrValue('foo').to.equal('abc')
+   *
+   * This is useful if there is no shortcut property for the attribute or
+   * you want to test access through the `.attributes.getValue(...)` mechanism.
+   */
+  utils.addMethod(Assertion.prototype, 'attrValue', function attrValue(name) {
+    this._obj = this._obj.attributes.getValue(name);
+  });
+});
+
+describe('API description namespace', () => {
+  context('category element', () => {
+    let category;
+
+    beforeEach(() => {
+      category = (new Category()).fromCompactRefract([
+        'category', {}, {}, [
+          ['category', {classes: ['resourceGroup']}, {}, []],
+          ['category', {classes: ['dataStructures']}, {}, []],
+          ['category', {classes: ['scenario']}, {}, []],
+          ['category', {classes: ['transitions']}, {}, []],
+          ['resource', {}, {}, []],
+          ['transition', {}, {}, []],
+          ['copy', {}, {}, '']
+        ]
+      ]);
+    });
+
+    it('should have element name category', () => {
+      expect(category.element).to.equal('category');
+    });
+
+    it('should contain a resource group', () => {
+      const items = category.resourceGroups;
+      expect(items).to.have.length(1);
+      items.forEach((item) => {
+        expect(item).to.be.an.instanceof(Category);
+        expect(item).to.have.class('resourceGroup');
+      });
+    });
+
+    it('should contain a data structure', () => {
+      const items = category.dataStructures;
+      expect(items).to.have.length(1);
+      items.forEach((item) => {
+        expect(item).to.be.an.instanceof(Category);
+        expect(item).to.have.class('dataStructures');
+      });
+    });
+
+    it('should contain a scenario', () => {
+      const items = category.scenarios;
+      expect(items).to.have.length(1);
+      items.forEach((item) => {
+        expect(item).to.be.an.instanceof(Category);
+        expect(item).to.have.class('scenario');
+      });
+    });
+
+    it('should contain a transition group', () => {
+      const items = category.transitionGroups;
+      expect(items).to.have.length(1);
+      items.forEach((item) => {
+        expect(item).to.be.an.instanceof(Category);
+        expect(item).to.have.class('transitions');
+      });
+    });
+
+    it('should contain a resource', () => {
+      const items = category.resources;
+      expect(items).to.have.length(1);
+      items.forEach((item) => {
+        expect(item).to.be.an.instanceof(Resource);
+      });
+    });
+
+    it('should contain a transition', () => {
+      const items = category.transitions;
+      expect(items).to.have.length(1);
+      items.forEach((item) => {
+        expect(item).to.be.an.instanceof(Transition);
+      });
+    });
+
+    it('should contain a copy element', () => {
+      const items = category.copy;
+      expect(items).to.have.length(1);
+      items.forEach((item) => {
+        expect(item).to.be.an.instanceof(Copy);
+      });
+    });
+  });
+
+  context('copy element', () => {
+    let copy;
+
+    beforeEach(() => {
+      copy = (new Copy()).fromCompactRefract(
+        ['copy', {}, {contentType: 'text/html'}, 'I am some text']
+      );
+    });
+
+    it('should have element name copy', () => {
+      expect(copy.element).to.equal('copy');
+    });
+
+    it('should have a content type', () => {
+      expect(copy.contentType).to.equal('text/html');
+    });
+
+    it('should set a content type', () => {
+      copy.contentType = 'text/plain';
+      expect(copy).attrValue('contentType').to.equal('text/plain');
+    });
+
+    it('should contain some text', () => {
+      expect(copy.content).to.equal('I am some text');
+    });
+  });
+
+  context('data structure element', () => {
+    let struct;
+
+    beforeEach(() => {
+      struct = new DataStructure('test');
+    });
+
+    it('should have element name dataStructure', () => {
+      expect(struct.element).to.equal('dataStructure');
+    });
+
+    it('should have element content', () => {
+      expect(struct.content).to.be.an.instanceof(BaseElement);
+    });
+
+    it('should get element content value', () => {
+      expect(struct.toValue()).to.equal('test');
+    });
+
+    it('should serialize to refract', () => {
+      const refract = struct.toRefract();
+      expect(refract).to.deep.equal({
+        element: 'dataStructure',
+        meta: {},
+        attributes: {},
+        content: {
+          element: 'string',
+          meta: {},
+          attributes: {},
+          content: 'test'
+        }
+      });
+    });
+
+    it('should serialize to compact refract', () => {
+      const refract = struct.toCompactRefract();
+      expect(refract).to.deep.equal(
+        ['dataStructure', {}, {},
+          ['string', {}, {}, 'test']
+        ]
+      );
+    });
+
+    it('should load from refract', () => {
+      const refract = struct.toRefract();
+      const loaded = (new DataStructure()).fromRefract(refract);
+      expect(loaded.toRefract()).to.deep.equal(refract);
+    });
+
+    it('should load from compact refract', () => {
+      const refract = struct.toCompactRefract();
+      const loaded = (new DataStructure()).fromCompactRefract(refract);
+      expect(loaded.toCompactRefract()).to.deep.equal(refract);
+    });
+  });
+
+  context('resource element', () => {
+    let resource;
+
+    beforeEach(() => {
+      resource = (new Resource()).fromCompactRefract(
+        ['resource', {}, {
+          href: '/resource/{id}',
+          hrefVariables: ['hrefVariables', {}, {}, [
+            ['member', {}, {}, {
+              key: ['string', {}, {}, 'id'],
+              value: ['string', {}, {}, '123']
+            }]
+          ]]
+        }, [
+          ['transition', {}, {}, []],
+          ['dataStructure', {}, {}, []]
+        ]]
+      );
+    });
+
+    it('should have element name resource', () => {
+      expect(resource.element).to.equal('resource');
+    });
+
+    it('should have an href', () => {
+      expect(resource.href).to.equal('/resource/{id}');
+    });
+
+    it('should set an href', () => {
+      resource.href = '/foo/{id}';
+      expect(resource).attrValue('href').to.equal('/foo/{id}');
+    });
+
+    it('should have hrefVariables', () => {
+      expect(resource.hrefVariables.toValue()).to.deep.equal({
+        id: '123'
+      });
+    });
+
+    it('should set hrefVariables', () => {
+      resource.hrefVariables = {
+        id: '456'
+      };
+      expect(resource).attrValue('hrefVariables').to.deep.equal({
+        id: '456'
+      });
+    });
+
+    it('should contain a transition', () => {
+      const items = resource.transitions;
+      expect(items).to.have.length(1);
+      items.forEach((item) => {
+        expect(item).to.be.an.instanceof(Transition);
+      });
+    });
+
+    it('should contain a data structure', () => {
+      expect(resource.dataStructure).to.be.an.instanceof(DataStructure);
+    });
+  });
+
+  context('transition element', () => {
+    let transition;
+
+    beforeEach(() => {
+      transition = (new Transition()).fromCompactRefract(
+        ['transition', {}, {
+          relation: 'action',
+          href: '/resource',
+          data: ['dataStructure', {}, {}, ['object', {}, {}, null]],
+          contentTypes: ['application/json']
+        }, [
+          ['httpTransaction', {}, {}, [
+            ['httpRequest', {}, {method: 'GET'}, []]
+          ]]
+        ]]
+      );
+    });
+
+    it('should have element name transition', () => {
+      expect(transition.element).to.equal('transition');
+    });
+
+    it('should have a method', () => {
+      expect(transition.method).to.equal('GET');
+    });
+
+    it('should have a relation', () => {
+      expect(transition.relation).to.equal('action');
+    });
+
+    it('should set a relation', () => {
+      transition.relation = 'delete';
+      expect(transition).attrValue('relation').to.equal('delete');
+    });
+
+    it('should have an href', () => {
+      expect(transition.href).to.equal('/resource');
+    });
+
+    it('should set an href', () => {
+      transition.href = '/foo/{id}';
+      expect(transition).attrValue('href').to.equal('/foo/{id}');
+    });
+
+    it('should have a computed href', () => {
+      expect(transition.computedHref).to.equal('/resource');
+      transition.href = undefined;
+      transition.transactions.first().request.attributes.set('href', '/foo');
+      expect(transition.computedHref).to.equal('/foo');
+    });
+
+    it('should have data', () => {
+      expect(transition.data.toValue()).to.deep.equal({});
+    });
+
+    it('should set data', () => {
+      transition.data = 'test';
+      expect(transition).attrValue('data').to.equal('test');
+    });
+
+    it('should have contentTypes', () => {
+      expect(transition.contentTypes.toValue()).to.deep.equal(
+        ['application/json']
+      );
+    });
+
+    it('should set contentTypes', () => {
+      transition.contentTypes = ['application/xml'];
+      expect(transition).attrValue('contentTypes').to.deep.equal(
+        ['application/xml']
+      );
+    });
+
+    it('should contain a transaction', () => {
+      const items = transition.transactions;
+      expect(items).to.have.length(1);
+      items.forEach((item) => {
+        expect(item).to.be.an.instanceof(HttpTransaction);
+      });
+    });
+  });
+
+  context('HTTP transaction element', () => {
+    let transaction;
+
+    beforeEach(() => {
+      transaction = (new HttpTransaction()).fromCompactRefract(
+        ['httpTransaction', {}, {}, [
+          ['httpRequest', {}, {}, []],
+          ['httpResponse', {}, {}, []]
+        ]]
+      );
+    });
+
+    it('should have element name httpTransaction', () => {
+      expect(transaction.element).to.equal('httpTransaction');
+    });
+
+    it('should have a request', () => {
+      expect(transaction.request).to.be.an.instanceof(HttpRequest);
+    });
+
+    it('should have a response', () => {
+      expect(transaction.response).to.be.an.instanceof(HttpResponse);
+    });
+  });
+
+  context('HTTP request element', () => {
+    let request;
+
+    beforeEach(() => {
+      request = (new HttpRequest()).fromCompactRefract(
+        ['httpRequest', {}, {
+          method: 'GET',
+          href: '/foo'
+        }, []]
+      );
+    });
+
+    it('should have element name httpRequest', () => {
+      expect(request.element).to.equal('httpRequest');
+    });
+
+    it('should have a method', () => {
+      expect(request.method).to.equal('GET');
+    });
+
+    it('should set a method', () => {
+      request.method = 'POST';
+      expect(request).attrValue('method').to.equal('POST');
+    });
+
+    it('should have an href', () => {
+      expect(request.href).to.equal('/foo');
+    });
+
+    it('should set an href', () => {
+      request.href = '/bar';
+      expect(request).attrValue('href').to.equal('/bar');
+    });
+
+    it('should inherit from HTTP message payload', () => {
+      expect(request).to.be.an.instanceof(HttpMessagePayload);
+    });
+  });
+
+  context('HTTP response element', () => {
+    let response;
+
+    beforeEach(() => {
+      response = (new HttpResponse()).fromCompactRefract(
+        ['httpResponse', {}, {
+          statusCode: 200
+        }, []]
+      );
+    });
+
+    it('should have element name httpResponse', () => {
+      expect(response.element).to.equal('httpResponse');
+    });
+
+    it('should have a status code', () => {
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should set a status code', () => {
+      response.statusCode = 404;
+      expect(response).attrValue('statusCode').to.equal(404);
+    });
+
+    it('should inherit from HTTP message payload', () => {
+      expect(response).to.be.an.instanceof(HttpMessagePayload);
+    });
+  });
+
+  context('HTTP message payload', () => {
+    let payload;
+
+    beforeEach(() => {
+      payload = (new HttpMessagePayload()).fromCompactRefract(
+        ['httpResponse', {}, {
+          headers: ['httpHeaders', {}, {}, [
+            ['member', {}, {}, {
+              key: ['string', {}, {}, 'Content-Type'],
+              value: ['string', {}, {}, 'application/json']
+            }],
+            ['member', {}, {}, {
+              key: ['string', {}, {}, 'Cache'],
+              value: ['string', {}, {}, 'no-cache']
+            }]
+          ]]
+        }, [
+          ['dataStructure', {}, {}, []],
+          ['asset', {classes: ['messageBody']}, {}, ''],
+          ['asset', {classes: ['messageBodySchema']}, {}, '']
+        ]]
+      );
+    });
+
+    it('should get headers', () => {
+      expect(payload.headers.toValue()).to.deep.equal([
+        ['Content-Type', 'application/json'],
+        ['Cache', 'no-cache']
+      ]);
+    });
+
+    it('should get a header by name', () => {
+      expect(payload.header('Cache')).to.deep.equal(['no-cache']);
+    });
+
+    it('should get content-type from header', () => {
+      expect(payload.contentType).to.equal('application/json');
+    });
+
+    it('should contain a data structure', () => {
+      expect(payload.dataStructure).to.be.an.instanceof(DataStructure);
+    });
+
+    it('should contain a message body', () => {
+      expect(payload.messageBody).to.be.an.instanceof(Asset);
+      expect(payload.messageBody).to.have.class('messageBody');
+    });
+
+    it('should contain a message body schema', () => {
+      expect(payload.messageBodySchema).to.be.an.instanceof(Asset);
+      expect(payload.messageBodySchema).to.have.class('messageBodySchema');
+    });
+  });
+});


### PR DESCRIPTION
This change implements the Refract [RFC 0003](https://github.com/refractproject/rfcs/blob/master/text/0003-class-rename.md) and [0004](https://github.com/refractproject/rfcs/blob/master/text/0004-clarify-api-namespace.md), as well as fixing an
issue with how data structures are handled.
- Update to [Minim 0.10.0](https://github.com/refractproject/minim/blob/master/CHANGELOG.md#0100---2015-08-18)
- Renames `class` -> `classes`
- Rebase `DataStructure` element on `BaseElement`
- Update API Blueprint serializer
- Update Swagger parser
- Update test fixtures
- Minor error handling fixes in MSON serializer.

Since the `dataStructure` element is no longer used in the MSON serializer, it now relies on whether a parent exists in order to know when to print out certain information (such as type attributes). Both the simple and more complex serializer test continue to work as expected with this change.
