### PR TITLE
Prevent installation of backward incompatible dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "description": "API Description SDK",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./lib/fury",
   "repository": {
@@ -26,7 +26,7 @@
     "babel-runtime": "^5.5.6",
     "drafter": "^0.2.5",
     "json-schema-deref-sync": "^0.1.1",
-    "minim": "^0.10.0",
+    "minim": "~0.10.0",
     "robotskirt": "",
     "sanitizer": "",
     "swig": "^1.4.2",


### PR DESCRIPTION
This creates a new patch release that pegs the minor version of `minim` because the 0.11.0 release of that library is backward-incompatible and will cause errors for downstream projects.

This patch release is required until #48 can be completed and the tooling (like [swagger2blueprint](https://github.com/apiaryio/swagger2blueprint)) can be updated.
