### PR TITLE
Fix Swagger parse bug when operationId is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "description": "API Description SDK",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./lib/fury",
   "repository": {

--- a/src/adapters/swagger20.es6
+++ b/src/adapters/swagger20.es6
@@ -186,7 +186,9 @@ export function parse({ source }, done) {
         transition.push(new Copy(transitionDescription));
       }
 
-      transition.meta.set('title', methodValue.operationId);
+      if (methodValue.operationId) {
+        transition.meta.set('title', methodValue.operationId);
+      }
 
       // For each uriParameter, create an hrefVariable
       if (uriParameters.length > 0) {

--- a/test/fixtures/adapters/swagger20/api-description-example.json
+++ b/test/fixtures/adapters/swagger20/api-description-example.json
@@ -72,9 +72,7 @@
       "content": [
         {
           "element": "transition",
-          "meta": {
-            "title": "onlyDefaultResponse"
-          },
+          "meta": {},
           "attributes": {},
           "content": [
             {

--- a/test/fixtures/adapters/swagger20/swagger-2.0-example.json
+++ b/test/fixtures/adapters/swagger20/swagger-2.0-example.json
@@ -42,8 +42,7 @@
                     }
                 },
                 "description": "Only default response set",
-                "summary": "",
-                "operationId": "onlyDefaultResponse"
+                "summary": ""
             }
         },
         "/pet": {


### PR DESCRIPTION
This fixes a bug where a title would be created as a Minim member element but then set to a value of `undefined` (causing crashes where a string was expected). Rather than creating this undefined value with a real, existing member element we should just not create the member unless the Swagger operation ID exists.

This was preventing the `swagger2blueprint` tool from processing some Swagger files that had operations without an operation ID. I've updated the test fixture to simulate this case for one of the operations, and have confirmed that the customer's file works as expected after the fix.
