### PR TITLE
Pass parse result through on errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- When a parser returns an error it is sometimes useful to inspect the parse result. This now gets passed back to the handler function and can be used to print more information, such as parser annotations, when an error occurs.
+
 # 1.0.2 - 2015-11-30
 
 - Upgrade Minim Parse Result to 0.2.1

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,6 @@
 # 1.0.0 - 2015-11-17
 
 - Remove legacy interface. The only available interface is now the Refract interface. In order to use it, you must load adapter modules to handle particular formats.
-- Use
 
 # 0.8.4 - 2015-07-30
 

--- a/src/fury.js
+++ b/src/fury.js
@@ -71,7 +71,7 @@ class Fury {
     if (adapter) {
       try {
         adapter.parse({generateSourceMap, minim, source}, (err, elements) => {
-          if (err) { return done(err); }
+          if (err) { return done(err, elements); }
 
           if (elements instanceof minim.BaseElement) {
             done(null, elements);

--- a/test/fury.js
+++ b/test/fury.js
@@ -44,7 +44,9 @@ const refractedApi = [
         ]],
       ]],
     ]],
-    ['annotation', {'classes': ['warning']}, {'code': 6, 'sourceMap': [['sourceMap', {}, {}, [0, 10]]]}, 'description'],
+    ['annotation', {'classes': ['warning']}, {'code': 6, 'sourceMap': [
+      ['sourceMap', {}, {}, [[0, 10]]],
+    ]}, 'description'],
   ]];
 
 describe('Nodes.js require', () => {
@@ -233,7 +235,7 @@ describe('Refract loader', () => {
       });
 
       it('should have a source map', () => {
-        assert.deepEqual(annotation.attributes.get('sourceMap').toValue(), [[0, 10]]);
+        assert.deepEqual(annotation.attributes.get('sourceMap').first().toValue(), [[0, 10]]);
       });
     });
 

--- a/test/fury.js
+++ b/test/fury.js
@@ -139,13 +139,15 @@ describe('Parser', () => {
     });
 
     it('should error on parser error', (done) => {
-      const expected = new Error();
+      const expectedError = new Error();
+      const expectedElements = {};
       fury.adapters[fury.adapters.length - 1].parse = (options, done2) => {
-        done2(expected);
+        done2(expectedError, expectedElements);
       };
 
-      fury.parse({source: 'dummy'}, (err) => {
-        assert.equal(err, expected);
+      fury.parse({source: 'dummy'}, (err, elements) => {
+        assert.equal(err, expectedError);
+        assert.equal(elements, expectedElements);
         done();
       });
     });


### PR DESCRIPTION
This change makes it possible to return an error from the parser but still also return a parse result, which may contain more or other useful information such as partially parsed results and annotations.

Also updated is an example using source maps that was no longer correct.

cc @smizell 
