### PR TITLE
Process API Elements by minim on error as well

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 2.1.0 - 2016-05-24
+
+- Elements returned from parse will always be an instance of minim elements
+
 # 2.0.0 - 2016-04-28
 
 - Upgrade Minim to 0.14.0 and thus remove the short hand notation in fury

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "description": "API Description SDK",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./lib/fury",
   "repository": {

--- a/src/fury.js
+++ b/src/fury.js
@@ -61,12 +61,12 @@ class Fury {
     if (adapter) {
       try {
         adapter.parse({generateSourceMap, minim, source}, (err, elements) => {
-          if (err) { return done(err, elements); }
-
-          if (elements instanceof minim.BaseElement) {
-            done(null, elements);
+          if (!elements) {
+            done(err);
+          } else if (elements instanceof minim.BaseElement) {
+            done(err, elements);
           } else {
-            done(null, this.load(elements));
+            done(err, this.load(elements));
           }
         });
       } catch (err) {

--- a/test/fury.js
+++ b/test/fury.js
@@ -278,7 +278,7 @@ describe('Parser', () => {
 
       fury.parse({source: 'dummy'}, (err, elements) => {
         assert.equal(err, expectedError);
-        assert.equal(elements, expectedElements);
+        assert.deepEqual(elements, fury.load(expectedElements));
         done();
       });
     });


### PR DESCRIPTION
Fury should wrap result of adapter even if an error has occurred.

**TODO** tests
