### PR TITLE
Allow supplying parserOptions to parse adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Enhancements
+
+- Fury will now allow you to pass down parser options down to the underlying
+  parse adapter using the `adapterOptions` parameter.
+
 # 2.1.0 - 2016-05-24
 
 - Elements returned from parse will always be an instance of minim elements

--- a/src/fury.js
+++ b/src/fury.js
@@ -43,7 +43,7 @@ class Fury {
    * then uses the adapter to convert into refract elements and loads
    * these into objects.
    */
-  parse({source, mediaType, generateSourceMap = false}, done) {
+  parse({source, mediaType, generateSourceMap = false, adapterOptions}, done) {
     let adapter;
 
     if (mediaType) {
@@ -60,7 +60,13 @@ class Fury {
 
     if (adapter) {
       try {
-        adapter.parse({generateSourceMap, minim, source}, (err, elements) => {
+        let options = {generateSourceMap, minim, source};
+
+        if (adapterOptions) {
+          options = Object.assign(options, adapterOptions);
+        }
+
+        adapter.parse(options, (err, elements) => {
           if (!elements) {
             done(err);
           } else if (elements instanceof minim.BaseElement) {

--- a/test/fury.js
+++ b/test/fury.js
@@ -250,6 +250,19 @@ describe('Parser', () => {
       });
     });
 
+    it('should pass adapter options during parsing', (done) => {
+      fury.adapters[fury.adapters.length - 1].parse = ({minim, source, testOption = false}, cb) => {
+        const BooleanElement = minim.getElementClass('boolean');
+        return cb(null, new BooleanElement(testOption));
+      };
+
+      fury.parse({source: 'dummy', adapterOptions: {testOption: true}}, (err, result) => {
+        assert.isNull(err);
+        assert.isTrue(result.content);
+        done();
+      });
+    });
+
     it('should serialize through mediatype', (done) => {
       fury.serialize({api: 'dummy', mediaType: 'text/vnd.passthrough'}, (err, serialized) => {
         assert.equal(serialized, 'dummy');


### PR DESCRIPTION
Allow supplying `parserOptions` to the parse function which allow you to pass options down to the underlying parser.
