### PR TITLE
Add an API to produce validation of an ADD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Master
+
+## Enhancements
+
+- Fury will now allow you to `validate` an API Description.
+
 # 2.2.0 - 2016-09-01
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 2.3.0 - 2016-10-24
 
 ## Enhancements
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ export function parse({minim, generateSourceMap, source}, done) {
   done(null, elements);
 }
 
+export function validate({minim, source}, done) {
+  // Here you validate the source and return a parse result for any warnings or
+  // errors.
+  //
+  // NOTE: Implementing `validate` is optional, Fury will fallback to using
+  // `parse` to find warnings or errors.
+  done(null, null);
+}
+
 export function serialize({api, minim}, done) {
   // Here you convert `api` from javascript element objects to the serialized
   // source format.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "description": "API Description SDK",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./lib/fury",
   "repository": {

--- a/test/validate.js
+++ b/test/validate.js
@@ -1,0 +1,167 @@
+import {expect} from 'chai';
+import {Fury} from '../src/fury';
+
+describe('Validation', () => {
+  context('with a validate adapter', () => {
+    let shouldDetect;
+    let result;
+
+    const fury = new Fury();
+
+    fury.use({
+      name: 'passthrough',
+      mediaTypes: ['text/vnd.passthrough'],
+      detect: () => shouldDetect,
+      validate: ({}, done) => done(null, result),
+    });
+
+    beforeEach(() => {
+      shouldDetect = false;
+      result = null;
+    });
+
+    it('should validate through mediatype', (done) => {
+      fury.validate({source: 'dummy', mediaType: 'text/vnd.passthrough'}, (err, res) => {
+        expect(err).to.be.null;
+        expect(res).to.be.null;
+        done();
+      });
+    });
+
+    it('should validate through autodetect', (done) => {
+      shouldDetect = true;
+
+      fury.validate({source: 'dummy'}, (err, res) => {
+        expect(err).to.be.null;
+        expect(res).to.be.null;
+        done();
+      });
+    });
+
+    it('should error when validating with no matching validator', (done) => {
+      fury.validate({source: 'dummy'}, (err, res) => {
+        expect(err).not.to.be.null;
+        expect(res).to.be.null;
+        done();
+      });
+    });
+
+    it('should convert an object parse result into minim elements', (done) => {
+      shouldDetect = true;
+      result = {
+        'element': 'parseResult',
+        'content': [
+          {
+            'element': 'annotation',
+            'meta': {'classes': ['warning']},
+            'content': 'a wild warning appeared',
+          },
+        ],
+      };
+
+      fury.validate({source: 'dummy'}, (err, res) => {
+        expect(err).to.be.null;
+        expect(res.toRefract()).to.deep.equal({
+          'element': 'parseResult',
+          'meta': {},
+          'attributes': {},
+          'content': [
+            {
+              'element': 'annotation',
+              'meta': {'classes': ['warning']},
+              'attributes': {},
+              'content': 'a wild warning appeared',
+            },
+          ],
+        });
+        done();
+      });
+    });
+
+    it('should pass adapter options during validation', (done) => {
+      shouldDetect = true;
+      fury.adapters[0].validate = ({minim, source, testOption = false}, cb) => {
+        const BooleanElement = minim.getElementClass('boolean');
+        return cb(null, new BooleanElement(testOption));
+      };
+
+      fury.validate({source: 'dummy', adapterOptions: {testOption: true}}, (err, res) => {
+        expect(err).to.be.null;
+        expect(res.content).to.be.true;
+        done();
+      });
+    });
+  });
+
+  context('with a parse adapter without validate', () => {
+    let result = null;
+    const fury = new Fury();
+
+    fury.use({
+      name: 'passthrough',
+      mediaTypes: ['text/vnd.passthrough'],
+      detect: ({}) => true,
+      parse: ({}, done) => done(null, result),
+    });
+
+    before(() => {
+      result = null;
+    });
+
+    it('should validate when there are no annotations', (done) => {
+      result = {
+        'element': 'parseResult',
+        'content': [
+          {
+            'element': 'category',
+            'meta': {'classes': ['api']},
+            'content': [],
+          },
+        ],
+      };
+
+      fury.validate({source: 'dummy', mediaType: 'text/vnd.passthrough'}, (err, res) => {
+        expect(err).to.be.null;
+        expect(res).to.be.null;
+        done();
+      });
+    });
+
+    it('should validate when there are annotations', (done) => {
+      result = {
+        'element': 'parseResult',
+        'content': [
+          {
+            'element': 'category',
+            'meta': {'classes': ['api']},
+            'content': [],
+          },
+          {
+            'element': 'annotation',
+            'meta': {'classes': ['warning']},
+            'content': 'a wild warning appeared',
+          },
+        ],
+      };
+
+      fury.validate({source: 'dummy', mediaType: 'text/vnd.passthrough'}, (err, res) => {
+        expect(err).to.be.null;
+        expect(res.toRefract()).to.deep.equal({
+          'element': 'parseResult',
+          'meta': {},
+          'attributes': {},
+          'content': [
+            {
+              'element': 'annotation',
+              'meta': {'classes': ['warning']},
+              'attributes': {},
+              'content': 'a wild warning appeared',
+            },
+          ],
+        });
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Takes an ADD, and can validate the ADD providing the matched adapter supports validation. If the adapter does not, we will fallback to calling parse and only exposing the annotations.

``` js
fury.validate({source: 'Hello World'}, (err, result) => {
  console.log(err);
  console.log(result);
});
```
