### PR TITLE
Allow detecting adapter for given ADD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Master
+
+## Enhancements
+
+- Fury contains a `detect` method which takes an API Description source and
+  returns the registered adapters which can handle the API Description
+  source.
+
 # 3.0.0-beta.2 - 2017-06-29
 
 - Update minim to 0.17.1

--- a/src/fury.js
+++ b/src/fury.js
@@ -41,6 +41,11 @@ class Fury {
     return this.minim.fromRefract(elements);
   }
 
+  // Returns an array of adapters which can handle the given API Description Source
+  detect(source) {
+    return this.adapters.filter(adapter => adapter.detect && adapter.detect(source));
+  }
+
   findAdapter(source, mediaType, method) {
     let adapter;
 

--- a/src/fury.js
+++ b/src/fury.js
@@ -47,22 +47,11 @@ class Fury {
   }
 
   findAdapter(source, mediaType, method) {
-    let adapter;
-
     if (mediaType) {
-      adapter = findAdapter(this.adapters, mediaType, method);
-    } else {
-      for (let i = 0; i < this.adapters.length; i += 1) {
-        const current = this.adapters[i];
-
-        if (current.detect && current.detect(source) && current[method]) {
-          adapter = this.adapters[i];
-          break;
-        }
-      }
+      return findAdapter(this.adapters, mediaType, method);
     }
 
-    return adapter;
+    return this.detect(source).filter(adapter => adapter[method])[0];
   }
 
   validate({ source, mediaType, adapterOptions }, done) {

--- a/test/fury.js
+++ b/test/fury.js
@@ -204,6 +204,30 @@ describe('Fury class', () => {
 
     assert.notDeepEqual(fury1.adapters, fury2.adapters);
   });
+
+  describe('detecting type', () => {
+    let localFury;
+    let adapter;
+
+    before(() => {
+      adapter = {
+        name: 'test',
+        mediaTypes: ['text/vnd.test', 'text/vnd.testing'],
+        detect: source => source === 'test',
+      };
+
+      localFury = new Fury();
+      localFury.use(adapter);
+    });
+
+    it('can detect adapters from the source', () => {
+      assert.deepEqual(localFury.detect('test'), [adapter]);
+    });
+
+    it('returns empty array when the type cannot be detected', () => {
+      assert.equal(localFury.detect('none').length, 0);
+    });
+  });
 });
 
 describe('Parser', () => {


### PR DESCRIPTION
Provide method to return all adapters that can handle the given API Description source, this was requested by @honzajavorek in https://github.com/apiaryio/fury.js/issues/62.

```js
const adapters = fury.detect('# My API Blueprint');

if (adapter[0]) {
  console.log(`Source was of type '${adapter.name}' with the content types: ${adapter.mediaTypes.join(', ')}`);
}

if (adapters.includes(apibParser)) {
  console.log('source can be parsed using apib parser');
}
```

@honzajavorek Does this work for you?
