### PR TITLE
Update to minim 0.18 (new serialisation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fury contains a `detect` method which takes an API Description source and
   returns the registered adapters which can handle the API Description
   source.
+- Updates to minim 0.18.0 which updates API Element and Refract serialisation.
 
 # 3.0.0-beta.2 - 2017-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 3.0.0-beta.3
 
 ## Enhancements
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.23.0",
-    "minim": "^0.17.1",
-    "minim-parse-result": "^0.6.1"
+    "minim": "^0.18.0",
+    "minim-parse-result": "^0.7.0"
   },
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fury",
   "description": "API Description SDK",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "author": "Apiary.io <support@apiary.io>",
   "main": "./lib/fury",
   "repository": {

--- a/test/fury.js
+++ b/test/fury.js
@@ -8,8 +8,19 @@ const refractedApi = {
     {
       element: 'category',
       meta: {
-        classes: ['api'],
-        title: 'My API',
+        classes: {
+          element: 'array',
+          content: [
+            {
+              element: 'string',
+              content: 'api',
+            },
+          ],
+        },
+        title: {
+          element: 'string',
+          content: 'My API',
+        },
       },
       content: [
         {
@@ -19,24 +30,44 @@ const refractedApi = {
         {
           element: 'category',
           meta: {
-            classes: ['resourceGroup'],
-            title: 'My Group',
+            classes: {
+              element: 'array',
+              content: [
+                {
+                  element: 'string',
+                  content: 'resourceGroup',
+                },
+              ],
+            },
+            title: {
+              element: 'string',
+              content: 'My Group',
+            },
           },
           content: [
             {
               element: 'copy',
               attributes: {
-                contentType: 'text/plain',
+                contentType: {
+                  element: 'string',
+                  content: 'text/plain',
+                },
               },
               content: 'This is a group of resources',
             },
             {
               element: 'resource',
               meta: {
-                title: 'Frob',
+                title: {
+                  element: 'string',
+                  content: 'Frob',
+                },
               },
               attributes: {
-                href: '/frobs/{id}',
+                href: {
+                  element: 'string',
+                  content: '/frobs/{id}',
+                },
                 hrefVariables: {
                   element: 'hrefVariables',
                   content: [
@@ -68,9 +99,16 @@ const refractedApi = {
                     content: [
                       {
                         element: 'member',
-                        meta: {},
                         attributes: {
-                          typeAttributes: ['required'],
+                          typeAttributes: {
+                            element: 'array',
+                            content: [
+                              {
+                                element: 'string',
+                                content: 'required',
+                              },
+                            ],
+                          },
                         },
                         content: {
                           key: {
@@ -109,20 +147,29 @@ const refractedApi = {
                     {
                       element: 'httpTransaction',
                       meta: {
-                        title: 'Get a frob',
+                        title: {
+                          element: 'string',
+                          content: 'Get a frob',
+                        },
                       },
                       content: [
                         {
                           element: 'httpRequest',
                           attributes: {
-                            method: 'GET',
+                            method: {
+                              element: 'string',
+                              content: 'GET',
+                            },
                           },
                           content: [],
                         },
                         {
                           element: 'httpResponse',
                           attributes: {
-                            statusCode: 200,
+                            statusCode: {
+                              element: 'number',
+                              content: 200,
+                            },
                             headers: {
                               element: 'httpHeaders',
                               content: [
@@ -146,7 +193,15 @@ const refractedApi = {
                             {
                               element: 'asset',
                               meta: {
-                                classes: ['messageBody'],
+                                classes: {
+                                  element: 'array',
+                                  content: [
+                                    {
+                                      element: 'string',
+                                      content: 'messageBody',
+                                    },
+                                  ],
+                                },
                               },
                               content: '{\n  "id": "1",\n  "tag": "foo"\n}\n',
                             },
@@ -165,16 +220,44 @@ const refractedApi = {
     {
       element: 'annotation',
       meta: {
-        classes: ['warning'],
+        classes: {
+          element: 'array',
+          content: [
+            {
+              element: 'string',
+              content: 'warning',
+            },
+          ],
+        },
       },
       attributes: {
-        code: 6,
-        sourceMap: [
-          {
-            element: 'sourceMap',
-            content: [[0, 10]],
-          },
-        ],
+        code: {
+          element: 'number',
+          content: 6,
+        },
+        sourceMap: {
+          element: 'array',
+          content: [
+            {
+              element: 'sourceMap',
+              content: [
+                {
+                  element: 'array',
+                  content: [
+                    {
+                      element: 'number',
+                      content: 0,
+                    },
+                    {
+                      element: 'number',
+                      content: 10,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       },
       content: 'description',
     },
@@ -311,7 +394,7 @@ describe('Parser', () => {
 
     it('should error on parser error', (done) => {
       const expectedError = new Error();
-      const expectedElements = {};
+      const expectedElements = { element: 'string', content: 'Hello' };
       fury.adapters[fury.adapters.length - 1].parse = (options, done2) => {
         done2(expectedError, expectedElements);
       };
@@ -371,7 +454,15 @@ describe('Refract loader', () => {
       const api = fury.load({
         element: 'category',
         meta: {
-          classes: 'api',
+          classes: {
+            element: 'array',
+            content: [
+              {
+                element: 'string',
+                content: 'api',
+              },
+            ],
+          },
         },
         content: [],
       });

--- a/test/validate.js
+++ b/test/validate.js
@@ -55,7 +55,17 @@ describe('Validation', () => {
         content: [
           {
             element: 'annotation',
-            meta: { classes: ['warning'] },
+            meta: {
+              classes: {
+                element: 'array',
+                content: [
+                  {
+                    element: 'string',
+                    content: 'warning',
+                  },
+                ],
+              },
+            },
             content: 'a wild warning appeared',
           },
         ],
@@ -68,7 +78,17 @@ describe('Validation', () => {
           content: [
             {
               element: 'annotation',
-              meta: { classes: ['warning'] },
+              meta: {
+                classes: {
+                  element: 'array',
+                  content: [
+                    {
+                      element: 'string',
+                      content: 'warning',
+                    },
+                  ],
+                },
+              },
               content: 'a wild warning appeared',
             },
           ],
@@ -113,7 +133,17 @@ describe('Validation', () => {
         content: [
           {
             element: 'category',
-            meta: { classes: ['api'] },
+            meta: {
+              classes: {
+                element: 'array',
+                content: [
+                  {
+                    element: 'string',
+                    content: 'api',
+                  },
+                ],
+              },
+            },
             content: [],
           },
         ],
@@ -132,12 +162,32 @@ describe('Validation', () => {
         content: [
           {
             element: 'category',
-            meta: { classes: ['api'] },
+            meta: {
+              classes: {
+                element: 'array',
+                content: [
+                  {
+                    element: 'string',
+                    content: 'api',
+                  },
+                ],
+              },
+            },
             content: [],
           },
           {
             element: 'annotation',
-            meta: { classes: ['warning'] },
+            meta: {
+              classes: {
+                element: 'array',
+                content: [
+                  {
+                    element: 'string',
+                    content: 'warning',
+                  },
+                ],
+              },
+            },
             content: 'a wild warning appeared',
           },
         ],
@@ -150,7 +200,17 @@ describe('Validation', () => {
           content: [
             {
               element: 'annotation',
-              meta: { classes: ['warning'] },
+              meta: {
+                classes: {
+                  element: 'array',
+                  content: [
+                    {
+                      element: 'string',
+                      content: 'warning',
+                    },
+                  ],
+                },
+              },
               content: 'a wild warning appeared',
             },
           ],


### PR DESCRIPTION
This updates minim/minim-api-description/minim-parse-result which follows Refract 1.0 serialisation rules and API Elements 1.0.

## Dependencies

- [x] https://github.com/refractproject/minim/pull/127
- [x] https://github.com/refractproject/minim-api-description/pull/30
- [x] https://github.com/refractproject/minim-parse-result/pull/22